### PR TITLE
fix style: move return statement from final else block

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -194,12 +194,13 @@ func (c *MOSNConfig) Mode() Mode {
 	if len(c.Servers) > 0 {
 		if len(c.RawStaticResources) == 0 || len(c.RawDynamicResources) == 0 {
 			return File
-		} else {
-			return Mix
 		}
+		
+		return Mix
 	} else if len(c.RawStaticResources) > 0 && len(c.RawDynamicResources) > 0 {
 		return Xds
 	}
+	
 	return File
 }
 

--- a/pkg/config/convertxds.go
+++ b/pkg/config/convertxds.go
@@ -298,9 +298,9 @@ func convertFilterConfig(name string, s *types.Struct) map[string]interface{} {
 			VirtualHosts:        convertVirtualHosts(filterConfig.GetRouteConfig()),
 		}
 		return structs.Map(proxyConfig)
-	} else {
-		log.DefaultLogger.Errorf("unsupport filter config, filter name: %s", name)
 	}
+	
+	log.DefaultLogger.Errorf("unsupport filter config, filter name: %s", name)
 	return nil
 }
 

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -84,9 +84,9 @@ func ParseLogLevel(level string) log.LogLevel {
 	if level != "" {
 		if logLevel, ok := logLevelMap[level]; ok {
 			return logLevel
-		} else {
-			log.StartLogger.Fatalln("unsupported log level: ", level)
 		}
+		
+		log.StartLogger.Fatalln("unsupported log level: ", level)
 	}
 	//use INFO as default log level
 	return log.INFO

--- a/pkg/filter/factory.go
+++ b/pkg/filter/factory.go
@@ -46,8 +46,8 @@ func CreateStreamFilterChainFactory(filterType string, config map[string]interfa
 		}
 
 		return sfcf
-	} else {
-		log.StartLogger.Fatalln("unsupport stream filter type: ", filterType)
-		return nil
 	}
+	
+	log.StartLogger.Fatalln("unsupport stream filter type: ", filterType)
+	return nil
 }

--- a/pkg/filter/network/faultinject/faultinject.go
+++ b/pkg/filter/network/faultinject/faultinject.go
@@ -44,9 +44,9 @@ func (fi *faultinjecter) OnData(buffer types.IoBuffer) types.FilterStatus {
 
 	if atomic.LoadUint32(&fi.delaying) > 0 {
 		return types.StopIteration
-	} else {
-		return types.Continue
 	}
+	
+	return types.Continue
 }
 
 func (fi *faultinjecter) OnNewConnection() types.FilterStatus {

--- a/pkg/filter/stream/faultinject/faultinject.go
+++ b/pkg/filter/stream/faultinject/faultinject.go
@@ -52,9 +52,9 @@ func (f *faultInjectFilter) OnDecodeHeaders(headers map[string]string, endStream
 
 	if atomic.LoadUint32(&f.delaying) > 0 {
 		return types.FilterHeadersStatusStopIteration
-	} else {
-		return types.FilterHeadersStatusContinue
 	}
+	
+	return types.FilterHeadersStatusContinue
 }
 
 func (f *faultInjectFilter) OnDecodeData(buf types.IoBuffer, endStream bool) types.FilterDataStatus {
@@ -62,9 +62,9 @@ func (f *faultInjectFilter) OnDecodeData(buf types.IoBuffer, endStream bool) typ
 
 	if atomic.LoadUint32(&f.delaying) > 0 {
 		return types.FilterDataStatusStopIterationAndBuffer
-	} else {
-		return types.FilterDataStatusContinue
 	}
+	
+	return types.FilterDataStatusContinue
 }
 
 func (f *faultInjectFilter) OnDecodeTrailers(trailers map[string]string) types.FilterTrailersStatus {
@@ -72,9 +72,9 @@ func (f *faultInjectFilter) OnDecodeTrailers(trailers map[string]string) types.F
 
 	if atomic.LoadUint32(&f.delaying) > 0 {
 		return types.FilterTrailersStatusStopIteration
-	} else {
-		return types.FilterTrailersStatusContinue
 	}
+	
+	return types.FilterTrailersStatusContinue
 }
 
 func (f *faultInjectFilter) SetDecoderFilterCallbacks(cb types.StreamReceiverFilterCallbacks) {

--- a/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
+++ b/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
@@ -83,9 +83,9 @@ func (f *healthCheckFilter) OnDecodeHeaders(headers map[string]string, endStream
 
 	if f.intercept {
 		return types.FilterHeadersStatusStopIteration
-	} else {
-		return types.FilterHeadersStatusContinue
 	}
+	
+	return types.FilterHeadersStatusContinue
 }
 
 func (f *healthCheckFilter) OnDecodeData(buf types.IoBuffer, endStream bool) types.FilterDataStatus {
@@ -95,9 +95,9 @@ func (f *healthCheckFilter) OnDecodeData(buf types.IoBuffer, endStream bool) typ
 
 	if f.intercept {
 		return types.FilterDataStatusStopIterationNoBuffer
-	} else {
-		return types.FilterDataStatusContinue
 	}
+	
+	return types.FilterDataStatusContinue
 }
 
 func (f *healthCheckFilter) OnDecodeTrailers(trailers map[string]string) types.FilterTrailersStatus {
@@ -107,9 +107,9 @@ func (f *healthCheckFilter) OnDecodeTrailers(trailers map[string]string) types.F
 
 	if f.intercept {
 		return types.FilterTrailersStatusStopIteration
-	} else {
-		return types.FilterTrailersStatusContinue
 	}
+	
+	return types.FilterTrailersStatusContinue
 }
 
 func (f *healthCheckFilter) handleIntercept() {

--- a/pkg/network/buffer/iobuffer.go
+++ b/pkg/network/buffer/iobuffer.go
@@ -110,12 +110,13 @@ func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, err error) {
 			if !first {
 				if te, ok := err.(net.Error); ok && te.Timeout() {
 					return n, nil
-				} else {
-					return n, e
 				}
-			} else {
+				
 				return n, e
+				
 			}
+			
+			return n, e
 		}
 
 		b.buf = b.buf[0: len(b.buf)+m]

--- a/pkg/network/buffer/iobuffer.go
+++ b/pkg/network/buffer/iobuffer.go
@@ -111,9 +111,6 @@ func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, err error) {
 				if te, ok := err.(net.Error); ok && te.Timeout() {
 					return n, nil
 				}
-				
-				return n, e
-				
 			}
 			
 			return n, e

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -582,9 +582,9 @@ func (c *connection) GetWriteBuffer() []types.IoBuffer {
 func (c *connection) GetReadBuffer() types.IoBuffer {
 	if c.readBuffer != nil {
 		return c.readBuffer.Br
-	} else {
-		return nil
 	}
+	
+	return nil
 }
 
 func (c *connection) FilterManager() types.FilterManager {

--- a/pkg/protocol/sofarpc/adapter.go
+++ b/pkg/protocol/sofarpc/adapter.go
@@ -35,13 +35,13 @@ func GetPropertyValue(properHeaders map[string]reflect.Kind, headers map[string]
 		delete(headers, propertyHeaderName)
 
 		return ConvertPropertyValue(value, properHeaders[name])
-	} else {
-		if value, ok := headers[name]; ok {
-
-			return ConvertPropertyValue(value, properHeaders[name])
-		}
 	}
+	
+	if value, ok := headers[name]; ok {
 
+		return ConvertPropertyValue(value, properHeaders[name])
+	}
+	
 	return nil
 }
 

--- a/pkg/protocol/sofarpc/protocols.go
+++ b/pkg/protocol/sofarpc/protocols.go
@@ -74,13 +74,13 @@ func (p *protocols) EncodeHeaders(context context.Context, headers interface{}) 
 	if proto, exists := p.protocolMaps[protocolCode]; exists {
 		//Return encoded data in map[string]string to stream layer
 		return proto.GetEncoder().EncodeHeaders(context, headers)
-	} else {
-		errMsg := types.UnSupportedProCode
-		err := errors.New(errMsg)
-		log.ByContext(context).Errorf(errMsg + "protocolCode = %s", protocolCode)
-
-		return err, nil
 	}
+	
+	errMsg := types.UnSupportedProCode
+	err := errors.New(errMsg)
+	log.ByContext(context).Errorf(errMsg + "protocolCode = %s", protocolCode)
+	
+	return err, nil
 }
 
 func (p *protocols) EncodeData(context context.Context, data types.IoBuffer) types.IoBuffer {

--- a/pkg/protocol/sofarpc/types.go
+++ b/pkg/protocol/sofarpc/types.go
@@ -350,10 +350,11 @@ func BuildSofaRespMsg(context context.Context, headers map[string]string, respSt
 		}, nil
 	} else if pro == PROTOCOL_CODE_TR {
 		return headers, nil
-	} else {
-		log.ByContext(context).Errorf("[BuildSofaRespMsg Error]Unknown Protocol Code")
-		return headers, errors.New(types.UnSupportedProCode)
 	}
+	
+	log.ByContext(context).Errorf("[BuildSofaRespMsg Error]Unknown Protocol Code")
+	
+	return headers, errors.New(types.UnSupportedProCode)
 }
 
 // Sofa Rpc Default HC Parameters

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -801,9 +801,9 @@ func (s *downStream) ComputeHashKey() types.HashedValue {
 func (s *downStream) MetadataMatchCriteria() types.MetadataMatchCriteria {
 	if nil != s.requestInfo.RouteEntry() {
 		return s.requestInfo.RouteEntry().MetadataMatchCriteria()
-	} else {
-		return nil
 	}
+	
+	return nil
 }
 
 func (s *downStream) DownstreamConnection() net.Conn {

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -62,11 +62,11 @@ func (s *downStream) runAppendHeaderFilters(filter *activeStreamSenderFilter, he
 			f.stopped = true
 
 			return true
-		} else {
-			f.headersContinued = true
-
-			return false
 		}
+		
+		f.headersContinued = true
+
+		return false
 	}
 
 	return false
@@ -163,11 +163,11 @@ func (s *downStream) runReceiveHeadersFilters(filter *activeStreamReceiverFilter
 			f.stopped = true
 
 			return true
-		} else {
-			f.headersContinued = true
-
-			return false
 		}
+		
+		f.headersContinued = true
+		
+		return false
 	}
 
 	return false

--- a/pkg/router/basic/router.go
+++ b/pkg/router/basic/router.go
@@ -155,9 +155,9 @@ func NewRouters(config interface{}) (types.Routers, error) {
 		//router.RoutersManager.AddRoutersSet(rc)
 		return rc, nil
 
-	} else {
-		return nil, errors.New("invalid config struct")
 	}
+	
+	return nil, errors.New("invalid config struct")
 }
 
 func (srr *basicRouter) Match(headers map[string]string, randomValue uint64) types.Route {
@@ -176,10 +176,9 @@ func (srr *basicRouter) Match(headers map[string]string, randomValue uint64) typ
 
 	if srr.service == service {
 		return srr
-	} else {
-		return nil
 	}
-	return srr
+	
+	return nil
 }
 
 func (srr *basicRouter) RedirectRule() types.RedirectRule {

--- a/pkg/router/configutility.go
+++ b/pkg/router/configutility.go
@@ -80,18 +80,17 @@ type QueryParameterMatcher struct {
 }
 
 func (qpm *QueryParameterMatcher) Matches(requestQueryParams types.QueryParams) bool {
-
-	if requestQueryValue, ok := requestQueryParams[qpm.name]; !ok {
+	requestQueryValue, ok := requestQueryParams[qpm.name]
+	
+	if !ok {
 		return false
 	} else if qpm.isRegex {
 		return qpm.regexPattern.MatchString(requestQueryValue)
 	} else if qpm.value == "" {
 		return true
-	} else {
-		return qpm.value == requestQueryValue
 	}
-
-	return true
+	
+	return qpm.value == requestQueryValue
 }
 
 // Implementation of Config that reads from a proto file.

--- a/pkg/router/configutility.go
+++ b/pkg/router/configutility.go
@@ -81,15 +81,19 @@ type QueryParameterMatcher struct {
 
 func (qpm *QueryParameterMatcher) Matches(requestQueryParams types.QueryParams) bool {
 	requestQueryValue, ok := requestQueryParams[qpm.name]
-	
+
 	if !ok {
 		return false
-	} else if qpm.isRegex {
+	}
+
+	if qpm.isRegex {
 		return qpm.regexPattern.MatchString(requestQueryValue)
-	} else if qpm.value == "" {
+	}
+
+	if qpm.value == "" {
 		return true
 	}
-	
+
 	return qpm.value == requestQueryValue
 }
 

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -39,7 +39,7 @@ func RegisteRouterConfigFactory(port types.Protocol, factory configFactory) {
 func CreateRouteConfig(port types.Protocol, config interface{}) (types.Routers, error) {
 	if factory, ok := routerConfigFactories[port]; ok {
 		return factory(config) //call NewBasicRoute
-	} else {
-		return nil, errors.New(fmt.Sprintf("Unsupported protocol %s", port))
 	}
+	
+	return nil, errors.New(fmt.Sprintf("Unsupported protocol %s", port))
 }

--- a/pkg/router/routeruleimpl.go
+++ b/pkg/router/routeruleimpl.go
@@ -185,11 +185,9 @@ func (rri *RouteRuleImplBase) matchRoute(headers map[string]string, randomValue 
 
 	if len(queryParams) == 0 {
 		return true
-	} else {
-		return ConfigUtilityInst.MatchQueryParams(queryParams, rri.configQueryParameters)
 	}
-
-	return true
+	
+	return ConfigUtilityInst.MatchQueryParams(queryParams, rri.configQueryParameters)
 }
 
 type SofaRouteRuleImpl struct {
@@ -215,10 +213,10 @@ func (srri *SofaRouteRuleImpl) Match(headers map[string]string, randomValue uint
 		} else {
 			log.DefaultLogger.Warnf(" Sofa router matches failure, service name = %s", value)
 		}
-	} else {
-		log.DefaultLogger.Warnf("No service key found in header, sofa router matcher failure")
 	}
-
+	
+	log.DefaultLogger.Warnf("No service key found in header, sofa router matcher failure")
+	
 	return nil
 }
 

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -141,9 +141,9 @@ func (ch *connHandler) FindListenerByAddress(addr net.Addr) types.Listener {
 
 	if l == nil {
 		return nil
-	} else {
-		return l.listener
 	}
+	
+	return l.listener
 }
 
 func (ch *connHandler) RemoveListeners(listenerTag uint64) {

--- a/pkg/stream/factory.go
+++ b/pkg/stream/factory.go
@@ -37,7 +37,7 @@ func CreateServerStreamConnection(context context.Context, prot types.Protocol, 
 
 	if ssc, ok := streamFactories[prot]; ok {
 		return ssc.CreateServerStream(context, connection, callbacks)
-	} else {
-		return nil
 	}
+	
+	return nil
 }

--- a/pkg/stream/sofarpc/stream.go
+++ b/pkg/stream/sofarpc/stream.go
@@ -345,9 +345,9 @@ func (m *streamMap) Has(streamId string) bool {
 
 	if _, ok := m.smap[streamId]; ok {
 		return true
-	} else {
-		return false
 	}
+	
+	return false
 }
 
 func (m *streamMap) Get(streamId string) (stream, bool) {
@@ -356,9 +356,9 @@ func (m *streamMap) Get(streamId string) (stream, bool) {
 
 	if s, ok := m.smap[streamId]; ok {
 		return s.(stream), ok
-	} else {
-		return stream{}, false
 	}
+	
+	return stream{}, false
 }
 
 func (m *streamMap) Remove(streamId string) {

--- a/pkg/stream/xprotocol/stream.go
+++ b/pkg/stream/xprotocol/stream.go
@@ -312,9 +312,9 @@ func (m *streamMap) Has(streamId string) bool {
 
 	if _, ok := m.smap[streamId]; ok {
 		return true
-	} else {
-		return false
 	}
+	
+	return false
 }
 
 func (m *streamMap) Get(streamId string) (stream, bool) {
@@ -323,9 +323,9 @@ func (m *streamMap) Get(streamId string) (stream, bool) {
 
 	if s, ok := m.smap[streamId]; ok {
 		return s.(stream), ok
-	} else {
-		return stream{}, false
 	}
+	
+	return stream{}, false
 }
 
 func (m *streamMap) Remove(streamId string) {

--- a/pkg/upstream/cluster/clustermanager.go
+++ b/pkg/upstream/cluster/clustermanager.go
@@ -120,9 +120,9 @@ func (cm *clusterManager) AddOrUpdatePrimaryCluster(cluster v2.Cluster) bool {
 func (cm *clusterManager) ClusterExist(clusterName string) bool {
 	if _, exist := cm.primaryClusters.Get(clusterName); exist {
 		return true
-	} else {
-		return false
 	}
+	
+	return false
 }
 
 func (cm *clusterManager) loadCluster(clusterConfig v2.Cluster, addedViaApi bool) types.Cluster {
@@ -153,9 +153,9 @@ func (cm *clusterManager) getOrCreateClusterSnapshot(clusterName string) *cluste
 		}
 		
 		return clusterSnapshot
-	} else {
-		return nil
 	}
+	
+	return nil
 }
 
 func (cm *clusterManager) SetInitializedCb(cb func()) {}
@@ -187,9 +187,9 @@ func (cm *clusterManager) UpdateClusterHosts(clusterName string, priority uint32
 			}
 			concretedCluster.UpdateHosts(hosts)
 			return nil
-		} else {
-			return errors.New(fmt.Sprintf("cluster's hostset %s can't be update", clusterName))
 		}
+		
+		return errors.New(fmt.Sprintf("cluster's hostset %s can't be update", clusterName))
 	}
 
 	return errors.New(fmt.Sprintf("cluster %s not found", clusterName))
@@ -246,30 +246,30 @@ func (cm *clusterManager) HttpConnPoolForCluster(lbCtx types.LoadBalancerContext
 
 		switch protocol {
 		case proto.Http2:
+			
 			if connPool, ok := cm.http2ConnPool.Get(addr); ok {
 				return connPool.(types.ConnectionPool)
-			} else {
-				// todo: move this to a centralized factory, remove dependency to http2 stream
-				connPool := http2.NewConnPool(host)
-				cm.http2ConnPool.Set(addr, connPool)
-
-				return connPool
 			}
+			// todo: move this to a centralized factory, remove dependency to http2 stream
+			connPool := http2.NewConnPool(host)
+			cm.http2ConnPool.Set(addr, connPool)
+
+			return connPool
 		case proto.Http1:
+			
 			if connPool, ok := cm.http1ConnPool.Get(addr); ok {
 				return connPool.(types.ConnectionPool)
-			} else {
-				// todo: move this to a centralized factory, remove dependency to http1 stream
-				connPool := http.NewConnPool(host)
-				cm.http1ConnPool.Set(addr, connPool)
-
-				return connPool
 			}
+			// todo: move this to a centralized factory, remove dependency to http1 stream
+			connPool := http.NewConnPool(host)
+			cm.http1ConnPool.Set(addr, connPool)
+
+			return connPool
 		}
 
 	}
+	
 	return nil
-
 }
 
 func (cm *clusterManager) XprotocolConnPoolForCluster(lbCtx types.LoadBalancerContext,cluster string,
@@ -288,12 +288,11 @@ func (cm *clusterManager) XprotocolConnPoolForCluster(lbCtx types.LoadBalancerCo
 
 		if connPool, ok := cm.xProtocolConnPool.Get(addr); ok {
 			return connPool.(types.ConnectionPool)
-		} else {
-			connPool := xprotocol.NewConnPool(host)
-			cm.xProtocolConnPool.Set(addr, connPool)
-
-			return connPool
 		}
+		connPool := xprotocol.NewConnPool(host)
+		cm.xProtocolConnPool.Set(addr, connPool)
+
+		return connPool
 	} else {
 		return nil
 	}
@@ -310,9 +309,9 @@ func (cm *clusterManager) TcpConnForCluster(lbCtx types.LoadBalancerContext,clus
 
 	if host != nil {
 		return host.CreateConnection(nil)
-	} else {
-		return types.CreateConnectionData{}
 	}
+	
+	return types.CreateConnectionData{}
 }
 
 func (cm *clusterManager) SofaRpcConnPoolForCluster(lbCtx types.LoadBalancerContext,cluster string) types.ConnectionPool {
@@ -331,17 +330,17 @@ func (cm *clusterManager) SofaRpcConnPoolForCluster(lbCtx types.LoadBalancerCont
 
 		if connPool, ok := cm.sofaRpcConnPool.Get(addr); ok {
 			return connPool.(types.ConnectionPool)
-		} else {
-			// todo: move this to a centralized factory, remove dependency to sofarpc stream
-			connPool := sofarpc.NewConnPool(host)
-			cm.sofaRpcConnPool.Set(addr, connPool)
-
-			return connPool
 		}
-	} else {
-		log.DefaultLogger.Errorf("clusterSnapshot.loadbalancer.ChooseHost is nil, cluster name = %s", cluster)
-		return nil
+		// todo: move this to a centralized factory, remove dependency to sofarpc stream
+		connPool := sofarpc.NewConnPool(host)
+		cm.sofaRpcConnPool.Set(addr, connPool)
+
+		return connPool
+		
 	}
+	
+	log.DefaultLogger.Errorf("clusterSnapshot.loadbalancer.ChooseHost is nil, cluster name = %s", cluster)
+	return nil
 }
 
 func (cm *clusterManager) RemovePrimaryCluster(clusterName string) bool {

--- a/pkg/upstream/healthcheck/healthchecker.go
+++ b/pkg/upstream/healthcheck/healthchecker.go
@@ -89,11 +89,11 @@ func (c *healthChecker) AddHostCheckCompleteCb(cb types.HealthCheckCb) {
 func (c *healthChecker) newSession(host types.Host) types.HealthCheckSession {
 	if c.sessionFactory != nil {
 		return c.sessionFactory.newSession(host)
-	} else {
-		return &healthCheckSession{
-			healthChecker: c,
-			host:          host,
-		}
+	}
+	
+	return &healthCheckSession{
+		healthChecker: c,
+		host:          host,
 	}
 }
 


### PR DESCRIPTION
修复

4.if block ends with a return statement, so drop this else and outdent its block
结尾的 else 中 有 return 的话单独提出来

，不标准写法：
func xxxx() xxx {
if f.intercept {
return types.FilterHeadersStatusStopIteration
} else {
return types.FilterHeadersStatusContinue
}
}
// -> 标准写法

func xxxx() xxx {
if f.intercept {
return types.FilterHeadersStatusStopIteration
}
return types.FilterHeadersStatusContinue
}