### PR TITLE
Optimize code pkg/network/commection.go

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -174,39 +174,40 @@ func (c *connection) startReadLoop() {
 			return
 		default:
 		}
-
+		
 		select {
 		case <-c.stopChan:
 			return
 		case <-c.internalStopChan:
 			return
 		case <-c.readEnabledChan:
+			continue
+		
 		default:
 			if c.readEnabled {
 				err := c.doRead()
-
-				if err != nil {
-
-					if err == io.EOF {
-						c.Close(types.NoFlush, types.RemoteClose)
-					} else {
-						c.Close(types.NoFlush, types.OnReadErrClose)
-					}
-
-					c.logger.Errorf("Error on read. Connection = %d, Remote Address = %s, err = %s",
-						c.id, c.RemoteAddr().String(), err)
-
-					return
+				
+				if err == nil {
+					runtime.Gosched()
+					continue
 				}
-			} else {
-				select {
-				case <-c.readEnabledChan:
-				case <-time.After(100 * time.Millisecond):
+				
+				
+				if err == io.EOF {
+					c.Close(types.NoFlush, types.RemoteClose)
+				} else {
+					c.Close(types.NoFlush, types.OnReadErrClose)
+					
 				}
+				
+				c.logger.Errorf("Error on read. Connection = %d, Remote Address = %s, err = %s",
+					c.id, c.RemoteAddr().String(), err)
+				
+				return
 			}
-
-			runtime.Gosched()
 		}
+		
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -174,7 +174,7 @@ func (c *connection) startReadLoop() {
 			return
 		default:
 		}
-		
+
 		select {
 		case <-c.stopChan:
 			return
@@ -182,7 +182,6 @@ func (c *connection) startReadLoop() {
 			return
 		case <-c.readEnabledChan:
 			continue
-		
 		default:
 			if c.readEnabled {
 				err := c.doRead()
@@ -197,7 +196,6 @@ func (c *connection) startReadLoop() {
 					c.Close(types.NoFlush, types.RemoteClose)
 				} else {
 					c.Close(types.NoFlush, types.OnReadErrClose)
-					
 				}
 				
 				c.logger.Errorf("Error on read. Connection = %d, Remote Address = %s, err = %s",


### PR DESCRIPTION
修正代码逻辑上的问题：
1. runtime.Gosched()在此处的目的应该是防止循环过快把进程夯住，是不是应该在select层外面
2. time.After(100 * time.Millisecond)应该有两个意思，一个是防止select卡住，一个也是防止循环太快，这样就和runtime.Gosched()的功能重复了，if嵌套select时序上也比较乱。

将else后面注解掉，在循环的末尾加上sleep是可以让出cpu时间的，runtime.Gosched()虽然可以让开cpu资源，但是循环对cpu的消耗依然比较高，修改后程序的时序和原来是没有太大差别的，阅读上也更简约一些。