### PR TITLE
Remove unwanted debug log in `protocols.go`

### DIFF
--- a/pkg/protocol/sofarpc/protocols.go
+++ b/pkg/protocol/sofarpc/protocols.go
@@ -129,7 +129,6 @@ func (p *protocols) RegisterProtocol(protocolCode byte, protocol Protocol) {
 		log.DefaultLogger.Warnf("protocol alreay Exist:", protocolCode)
 	} else {
 		p.protocolMaps[protocolCode] = protocol
-		log.StartLogger.Debugf("register protocol:%x", protocolCode)
 	}
 }
 


### PR DESCRIPTION
After compile mosn, when I type `mosn -v`, I got 

```
2018/07/20 00:35:49 [DEBUG]register protocol:1
2018/07/20 00:35:49 [DEBUG]register protocol:2
mosn version 0.0.1
```

There are some unwanted debug log.

