### PR TITLE
Fix Fuzzy case randomly failed

### DIFF
--- a/examples/sofarpc-sample/server.go
+++ b/examples/sofarpc-sample/server.go
@@ -56,7 +56,7 @@ func (s *SofaRPCServer) Serve(conn net.Conn) {
 					if err != nil {
 						fmt.Printf("[RPC Server] build response error: %v\n", err)
 					} else {
-						fmt.Printf("[RPC Server] reponse connection: %s, requestId: %d\n", conn.RemoteAddr().String(), resp.GetReqID)
+						fmt.Printf("[RPC Server] reponse connection: %s, requestId: %d\n", conn.RemoteAddr().String(), resp.GetReqID())
 						respdata := iobufresp.Bytes()
 						conn.Write(respdata)
 					}

--- a/test/fuzzy/http/server_test.go
+++ b/test/fuzzy/http/server_test.go
@@ -33,11 +33,13 @@ func TestServerCloseProxy(t *testing.T) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshProxy(t, stop, serverList, protocol.HTTP1)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshProxy(t, stopServer, serverList, protocol.HTTP1)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
@@ -46,11 +48,13 @@ func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshCluster(t, stop, serverList, protocol.HTTP1, proto)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshCluster(t, stopServer, serverList, protocol.HTTP1, proto)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func TestServerCloseToHTTP1(t *testing.T) {

--- a/test/fuzzy/http2/server_test.go
+++ b/test/fuzzy/http2/server_test.go
@@ -33,11 +33,13 @@ func TestServerCloseProxy(t *testing.T) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshProxy(t, stop, serverList, protocol.HTTP2)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshProxy(t, stopServer, serverList, protocol.HTTP2)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
@@ -46,11 +48,13 @@ func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshCluster(t, stop, serverList, protocol.HTTP2, proto)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshCluster(t, stopServer, serverList, protocol.HTTP2, proto)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func TestServerCloseToHTTP1(t *testing.T) {

--- a/test/fuzzy/rpc/client_test.go
+++ b/test/fuzzy/rpc/client_test.go
@@ -46,18 +46,22 @@ func TestClientCloseProxy(t *testing.T) {
 	caseIndex++
 	log.StartLogger.Infof("[FUZZY TEST] RPC ClientClose ProxyMode %d", caseIndex)
 	serverList := []string{"127.0.0.1:8081"}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshProxy(t, stop, serverList, protocol.SofaRPC)
-	CreateServers(t, serverList, stop)
-	runClientClose(t, stop, meshAddr)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshProxy(t, stopServer, serverList, protocol.SofaRPC)
+	CreateServers(t, serverList, stopServer)
+	runClientClose(t, stopClient, meshAddr)
+	close(stopServer)
 }
 
 func runClientCloseMeshToMesh(t *testing.T, proto types.Protocol) {
 	serverList := []string{"127.0.0.1:8081"}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshCluster(t, stop, serverList, protocol.SofaRPC, proto)
-	CreateServers(t, serverList, stop)
-	runClientClose(t, stop, meshAddr)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshCluster(t, stopServer, serverList, protocol.SofaRPC, proto)
+	CreateServers(t, serverList, stopServer)
+	runClientClose(t, stopClient, meshAddr)
+	close(stopServer)
 
 }
 func TestClientCloseToHTTP1(t *testing.T) {

--- a/test/fuzzy/rpc/server_test.go
+++ b/test/fuzzy/rpc/server_test.go
@@ -38,11 +38,13 @@ func TestServerCloseProxy(t *testing.T) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshProxy(t, stop, serverList, protocol.SofaRPC)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshProxy(t, stopServer, serverList, protocol.SofaRPC)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
@@ -51,11 +53,13 @@ func runServerCloseMeshToMesh(t *testing.T, proto types.Protocol) {
 		"127.0.0.1:8081",
 		"127.0.0.1:8082",
 	}
-	stop := make(chan struct{})
-	meshAddr := fuzzy.CreateMeshCluster(t, stop, serverList, protocol.SofaRPC, proto)
-	servers := CreateServers(t, serverList, stop)
-	fuzzy.FuzzyServer(stop, servers, caseDuration/5)
-	runClient(t, meshAddr, stop)
+	stopClient := make(chan struct{})
+	stopServer := make(chan struct{})
+	meshAddr := fuzzy.CreateMeshCluster(t, stopServer, serverList, protocol.SofaRPC, proto)
+	servers := CreateServers(t, serverList, stopServer)
+	fuzzy.FuzzyServer(stopServer, servers, caseDuration/5)
+	runClient(t, meshAddr, stopClient)
+	close(stopServer)
 }
 
 func TestServerCloseToHTTP1(t *testing.T) {

--- a/test/util/common.go
+++ b/test/util/common.go
@@ -7,11 +7,16 @@ import (
 )
 
 //tools
+var r *rand.Rand
+
+func init() {
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
 func RandomDuration(min, max time.Duration) time.Duration {
 	if min > max {
 		return min
 	}
-	d := rand.Int63n(int64(max - min))
+	d := r.Int63n(int64(max - min))
 	return time.Duration(d) * time.Nanosecond
 }
 func IsMapEmpty(m *sync.Map) bool {


### PR DESCRIPTION
1. close & restart server randomly, expected client will receive both failure and success response. but sometimes maybe no server close, makes the case fail.
2. at the end of cases, need make sure client closed before server
3. rand.Intn use the same source, different server need different source to make it more randomly