### PR TITLE
fix integrate test needs init stream

### DIFF
--- a/test/integrate/common_test.go
+++ b/test/integrate/common_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/alipay/sofa-mosn/pkg/protocol"
 	_ "github.com/alipay/sofa-mosn/pkg/protocol/sofarpc/codec"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/http"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/http2"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/sofarpc"
 	"github.com/alipay/sofa-mosn/test/util"
 )
 


### PR DESCRIPTION
ci check have bugs, sometimes it will not trigger integrate test check.
after merge #152 , it is needs to import stream/${protocol} to init