### PR TITLE
Remove HSF from feature list in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ follow-up development and build an open source boutique project together.
     + HTTP/1.1，HTTP/2.0
     + SOFARPC
     + Dubbo
-    + HSF(ongoing)
 + Routing support
     + Routing in form of virtual host
     + Routing with headers/url/prefix

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,7 +21,6 @@ MOSN是一款采用 Golang 开发的Service Mesh数据平面代理，功能和�
     + 支持HTTP/1.1，HTTP/2
     + 支持SOFARPC
     + 支持Dubbo协议（开发中）
-    + 支持HSF协议（开发中）
 + 核心路由
     + 支持virtual host路由
     + 支持headers/url/prefix路由


### PR DESCRIPTION
Remove HSF from feature list in README, HSF is not an open source protocol, should not listed or supported in open source version of SOFAMosn.