### PR TITLE
fix socket fd blocking

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -646,6 +646,8 @@ func (c *connection) Close(ccType types.ConnectionCloseType, eventType types.Con
 	} else if c.eventLoop != nil {
 		// unregister events while connection close
 		c.eventLoop.unregister(c.id)
+		// close copied fd
+		c.file.Close()
 	}
 
 	c.rawConnection.Close()

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -867,11 +867,15 @@ func (cc *clientConnection) Connect(ioEnabled bool) (err error) {
 		} else {
 			event = types.Connected
 
-			// store fd
-			if tc, ok := cc.rawConnection.(*net.TCPConn); ok {
-				cc.file, err = tc.File()
-				if err != nil {
-					return
+
+			// ensure ioEnabled and UseNetpollMode
+			if ioEnabled && UseNetpollMode {
+				// store fd
+				if tc, ok := cc.rawConnection.(*net.TCPConn); ok {
+					cc.file, err = tc.File()
+					if err != nil {
+						return
+					}
 				}
 			}
 

--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -438,8 +438,8 @@ func (c *connection) Write(buffers ...types.IoBuffer) error {
 		}
 
 	wait:
-	// we use for-loop with select:c.writeSchedChan to avoid chan-send blocking
-	// 'c.writeBufferChan <- &buffers' might block if write goroutine costs much time on 'doWriteIo'
+		// we use for-loop with select:c.writeSchedChan to avoid chan-send blocking
+		// 'c.writeBufferChan <- &buffers' might block if write goroutine costs much time on 'doWriteIo'
 		for {
 			select {
 			case c.writeBufferChan <- &buffers:
@@ -866,7 +866,6 @@ func (cc *clientConnection) Connect(ioEnabled bool) (err error) {
 			}
 		} else {
 			event = types.Connected
-
 
 			// ensure ioEnabled and UseNetpollMode
 			if ioEnabled && UseNetpollMode {

--- a/pkg/network/transfer.go
+++ b/pkg/network/transfer.go
@@ -458,14 +458,8 @@ func transferNewConn(conn net.Conn, buf []byte, handler types.ConnectionHandler,
 	}
 	ch := make(chan types.Connection)
 
-	// store fd for transfer connection
-	var file *os.File
-	if tc, ok := conn.(*net.TCPConn); ok {
-		file, _ = tc.File()
-	}
-
 	// new connection
-	go listener.GetListenerCallbacks().OnAccept(conn, false, nil, ch, buf, file)
+	go listener.GetListenerCallbacks().OnAccept(conn, false, nil, ch, buf)
 	select {
 	// recv connection
 	case rch := <-ch:

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -34,8 +34,8 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/filter/accept/originaldst"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/network"
-	"github.com/alipay/sofa-mosn/pkg/types"
 	"github.com/alipay/sofa-mosn/pkg/tls"
+	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
 // ConnectionHandler
@@ -350,12 +350,12 @@ func newActiveListener(listener types.Listener, lc *v2.ListenerConfig, logger lo
 		listener:                listener,
 		networkFiltersFactories: networkFiltersFactories,
 		streamFiltersFactories:  streamFiltersFactories,
-		conns:                   list.New(),
-		handler:                 handler,
-		stopChan:                stopChan,
-		logger:                  logger,
-		accessLogs:              accessLoggers,
-		updatedLabel:            false,
+		conns:        list.New(),
+		handler:      handler,
+		stopChan:     stopChan,
+		logger:       logger,
+		accessLogs:   accessLoggers,
+		updatedLabel: false,
 	}
 
 	listenPort := 0

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,13 +95,9 @@ func NewServer(config *Config, cmFilter types.ClusterManagerFilter, clMng types.
 }
 
 func (srv *server) AddListener(lc *v2.ListenerConfig, networkFiltersFactories []types.NetworkFilterChainFactory,
-	streamFiltersFactories []types.StreamFilterChainFactory) types.ListenerEventListener {
+	streamFiltersFactories []types.StreamFilterChainFactory) (types.ListenerEventListener, error) {
 
-	listener, err := srv.handler.AddOrUpdateListener(lc, networkFiltersFactories, streamFiltersFactories)
-	if err != nil {
-		log.StartLogger.Errorf("AddListener error:", err.Error())
-	}
-	return listener
+	return srv.handler.AddOrUpdateListener(lc, networkFiltersFactories, streamFiltersFactories)
 }
 
 func (srv *server) Start() {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -48,7 +48,7 @@ type Config struct {
 
 type Server interface {
 	AddListener(lc *v2.ListenerConfig, networkFiltersFactories []types.NetworkFilterChainFactory,
-		streamFiltersFactories []types.StreamFilterChainFactory) types.ListenerEventListener
+		streamFiltersFactories []types.StreamFilterChainFactory) (types.ListenerEventListener, error)
 
 	Start()
 

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -22,8 +22,6 @@ import (
 	"crypto/tls"
 	"net"
 
-	"os"
-
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/rcrowley/go-metrics"
 )
@@ -136,7 +134,7 @@ type TLSContextManager interface {
 // ListenerEventListener is a Callback invoked by a listener.
 type ListenerEventListener interface {
 	// OnAccept is called on new connection accepted
-	OnAccept(rawc net.Conn, handOffRestoredDestinationConnections bool, oriRemoteAddr net.Addr, c chan Connection, buf []byte, rawf *os.File)
+	OnAccept(rawc net.Conn, handOffRestoredDestinationConnections bool, oriRemoteAddr net.Addr, c chan Connection, buf []byte)
 
 	// OnNewConnection is called on new mosn connection created
 	OnNewConnection(ctx context.Context, conn Connection)


### PR DESCRIPTION
### Issues associated with this PR

FIX #210 

### Solutions
Only get socket fd when needed(conenction IO enable && UseNetpollMode), and it must be ahead of tls conn wrapper works. So we adjust the tlsMng from listener to activeListener

