### PR TITLE
fix #227 use uint32 as source

### DIFF
--- a/pkg/proxy/event.go
+++ b/pkg/proxy/event.go
@@ -36,12 +36,12 @@ type streamEvent struct {
 	stream    *downStream
 }
 
-func (s *streamEvent) Source() int {
-	source, err := strconv.ParseInt(s.streamID, 10, 32)
+func (s *streamEvent) Source() uint32 {
+	source, err := strconv.ParseUint(s.streamID, 10, 32)
 	if err != nil {
 		panic("streamID must be numeric, unexpected :" + s.streamID)
 	}
-	return int(source)
+	return uint32(source)
 }
 
 type startEvent struct {

--- a/pkg/sync/types.go
+++ b/pkg/sync/types.go
@@ -23,7 +23,7 @@ type WorkerFunc func(shard int, jobCh <-chan interface{})
 // ShardJob represents a job with its shard source.
 type ShardJob interface {
 	// Source get the job identifier for sharding.
-	Source() int
+	Source() uint32
 }
 
 // ShardWorkerPool provides a pool for goroutines, the actual goroutines themselves are assumed permanent running
@@ -40,7 +40,7 @@ type ShardWorkerPool interface {
 	Init()
 
 	// Shard get the real shard of giving source, this may helps in case like global object accessing.
-	Shard(source int) int
+	Shard(source uint32) uint32
 
 	// Offer puts the job into the corresponding shard and execute it.
 	Offer(job ShardJob)

--- a/pkg/sync/workerpool.go
+++ b/pkg/sync/workerpool.go
@@ -78,8 +78,8 @@ func (pool *shardWorkerPool) Init() {
 	}
 }
 
-func (pool *shardWorkerPool) Shard(source int) int {
-	return source % pool.numShards
+func (pool *shardWorkerPool) Shard(source uint32) uint32 {
+	return source % uint32(pool.numShards)
 }
 
 func (pool *shardWorkerPool) Offer(job ShardJob) {

--- a/pkg/sync/workerpool_test.go
+++ b/pkg/sync/workerpool_test.go
@@ -30,8 +30,8 @@ type TestJob struct {
 	i uint32
 }
 
-func (t *TestJob) Source() int {
-	return int(t.i)
+func (t *TestJob) Source() uint32 {
+	return t.i
 }
 
 // TestJobOrder test worker pool's event dispatch functionality, which should ensure the FIFO order


### PR DESCRIPTION
### Issues associated with this PR

#227 

### Sign the CLA
Make sure you has singed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions

request id in sofa rpc have 4 bytes, should use uint32 to represent

### UT result

UT test pass, no new unit test

### Benchmark

No Benchmark

### Code Style

+ Make sure `Goimports` has run
+ Show `Golint` result
