### PR TITLE
fix#284

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -420,6 +420,12 @@ func (c *connection) onRead(bytesRead int64) {
 }
 
 func (c *connection) Write(buffers ...types.IoBuffer) error {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Errorf("Write panic %v", r)
+		}
+	}()
+
 	fs := c.filterManager.OnWrite(buffers)
 
 	if fs == types.StopIteration {
@@ -649,6 +655,7 @@ func (c *connection) Close(ccType types.ConnectionCloseType, eventType types.Con
 	if c.internalLoopStarted {
 		// because close function must be called by one io loop thread, notify another loop here
 		close(c.internalStopChan)
+		close(c.writeBufferChan)
 	} else if c.eventLoop != nil {
 		// unregister events while connection close
 		c.eventLoop.unregister(c.id)

--- a/pkg/proxy/event.go
+++ b/pkg/proxy/event.go
@@ -104,7 +104,7 @@ func eventProcess(shard int, streamMap map[string]bool, event interface{}) {
 		e := event.(*resetEvent)
 		//log.DefaultLogger.Errorf("[reset] %d %d %s", shard, e.direction, e.streamID)
 
-		if done, ok := streamMap[e.streamID]; ok && !(done || streamProcessDone(e.stream)) {
+		if _, ok := streamMap[e.streamID]; ok {
 			switch e.direction {
 			case Downstream:
 				e.stream.ResetStream(e.reason)


### PR DESCRIPTION
### Issues associated with this PR

#284 
1. 当负载很高，upstream数量少的场景下，Write操作会把writeBufferChan填满，然后workerpool协程将处于等待状态，但如果这个时候upstream连接被关闭，导致wirteloop协程退出，也就不能消费writeBufferChan，最终将导致workerpool死锁，导致程序hung住。
   修复： 在连接被关闭的时候，同时关闭writeBufferChan， 避免workpool协程死锁。
   todo ： 重试机制
2. reset事件没有被处理，导致被reset的stream不会被删除，内存不能被gc回收。


### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
