### PR TITLE
fix #349, add SetResponseCode function in RequestInfo interface

### DIFF
--- a/pkg/network/requestinfo.go
+++ b/pkg/network/requestinfo.go
@@ -105,6 +105,10 @@ func (r *RequestInfo) ResponseCode() uint32 {
 	return r.responseCode
 }
 
+func (r *RequestInfo) SetResponseCode(code uint32) {
+	r.responseCode = code
+}
+
 func (r *RequestInfo) Duration() time.Duration {
 	return time.Now().Sub(r.startTime)
 }

--- a/pkg/protocol/types.go
+++ b/pkg/protocol/types.go
@@ -36,6 +36,7 @@ const (
 	MosnHeaderQueryStringKey  = "querystring"
 	MosnHeaderMethod          = "method"
 	MosnOriginalHeaderPathKey = "x-mosn-original-path"
+	MosnResponseStatusCode    = "response-code"
 )
 
 // Hseader with special meaning in istio

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -675,6 +675,11 @@ func (s *downStream) onUpstreamReset(urtype UpstreamResetType, reason types.Stre
 func (s *downStream) onUpstreamHeaders(headers types.HeaderMap, endStream bool) {
 	s.downstreamRespHeaders = headers
 
+	status, _ := s.downstreamRespHeaders.Get(types.HeaderStatus)
+	if code, err := strconv.Atoi(status); err == nil {
+		s.requestInfo.SetResponseCode(uint32(code))
+	}
+
 	// check retry
 	if s.retryState != nil {
 		retryCheck := s.retryState.retry(headers, "", s.doRetry)
@@ -719,6 +724,7 @@ func (s *downStream) onUpstreamResponseRecvFinished() {
 	if !s.upstreamRequestSent {
 		s.upstreamRequest.resetStream()
 	}
+
 
 	// todo: stats
 	// todo: logs

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -675,11 +675,6 @@ func (s *downStream) onUpstreamReset(urtype UpstreamResetType, reason types.Stre
 func (s *downStream) onUpstreamHeaders(headers types.HeaderMap, endStream bool) {
 	s.downstreamRespHeaders = headers
 
-	status, _ := s.downstreamRespHeaders.Get(types.HeaderStatus)
-	if code, err := strconv.Atoi(status); err == nil {
-		s.requestInfo.SetResponseCode(uint32(code))
-	}
-
 	// check retry
 	if s.retryState != nil {
 		retryCheck := s.retryState.retry(headers, "", s.doRetry)

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -20,6 +20,7 @@ package proxy
 import (
 	"container/list"
 	"context"
+	"strconv"
 
 	"github.com/alipay/sofa-mosn/pkg/buffer"
 	"github.com/alipay/sofa-mosn/pkg/log"
@@ -87,6 +88,13 @@ func (r *upstreamRequest) ResetStream(reason types.StreamResetReason) {
 // types.StreamReceiver
 // Method to decode upstream's response message
 func (r *upstreamRequest) OnReceiveHeaders(context context.Context, headers types.HeaderMap, endStream bool) {
+	// save response code
+	status, ok := context.Value(types.ContextKeyStatusCode).(string); if ok {
+		if code, err := strconv.Atoi(status); err == nil {
+			r.downStream.requestInfo.SetResponseCode(uint32(code))
+		}
+	}
+
 	buffer.TransmitBufferPoolContext(r.downStream.context, context)
 
 	workerPool.Offer(&receiveHeadersEvent{

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -89,10 +89,11 @@ func (r *upstreamRequest) ResetStream(reason types.StreamResetReason) {
 // Method to decode upstream's response message
 func (r *upstreamRequest) OnReceiveHeaders(context context.Context, headers types.HeaderMap, endStream bool) {
 	// save response code
-	if status, ok := context.Value(types.ContextKeyStatusCode).(string); ok {
+	if status, ok := headers.Get(protocol.MosnResponseStatusCode); ok {
 		if code, err := strconv.Atoi(status); err == nil {
 			r.downStream.requestInfo.SetResponseCode(uint32(code))
 		}
+		headers.Del(protocol.MosnResponseStatusCode)
 	}
 
 	buffer.TransmitBufferPoolContext(r.downStream.context, context)

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -89,7 +89,7 @@ func (r *upstreamRequest) ResetStream(reason types.StreamResetReason) {
 // Method to decode upstream's response message
 func (r *upstreamRequest) OnReceiveHeaders(context context.Context, headers types.HeaderMap, endStream bool) {
 	// save response code
-	status, ok := context.Value(types.ContextKeyStatusCode).(string); if ok {
+	if status, ok := context.Value(types.ContextKeyStatusCode).(string); ok {
 		if code, err := strconv.Atoi(status); err == nil {
 			r.downStream.requestInfo.SetResponseCode(uint32(code))
 		}

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -362,7 +362,13 @@ func (s *clientStream) doSend() {
 
 func (s *clientStream) handleResponse() {
 	if s.response != nil {
-		s.receiver.OnReceiveHeaders(s.context, protocol.CommonHeader(decodeRespHeader(s.response.Header)), false)
+		out := protocol.CommonHeader(decodeRespHeader(s.response.Header))
+		// save response code in context
+		status, exist := out.Get(types.HeaderStatus); if exist {
+			s.context = context.WithValue(s.context, types.ContextKeyStatusCode, status)
+		}
+
+		s.receiver.OnReceiveHeaders(s.context, protocol.CommonHeader(out), false)
 		buf := buffer.NewIoBufferBytes(s.response.Body())
 		s.receiver.OnReceiveData(s.context, buf, true)
 

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -362,13 +362,13 @@ func (s *clientStream) doSend() {
 
 func (s *clientStream) handleResponse() {
 	if s.response != nil {
-		out := protocol.CommonHeader(decodeRespHeader(s.response.Header))
+		decodeRespHeader := protocol.CommonHeader(decodeRespHeader(s.response.Header))
 		// save response code in context
-		status, exist := out.Get(types.HeaderStatus); if exist {
+		if status, exist := decodeRespHeader.Get(types.HeaderStatus); exist {
 			s.context = context.WithValue(s.context, types.ContextKeyStatusCode, status)
 		}
 
-		s.receiver.OnReceiveHeaders(s.context, protocol.CommonHeader(out), false)
+		s.receiver.OnReceiveHeaders(s.context, decodeRespHeader, false)
 		buf := buffer.NewIoBufferBytes(s.response.Body())
 		s.receiver.OnReceiveData(s.context, buf, true)
 

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -365,7 +365,7 @@ func (s *clientStream) handleResponse() {
 		decodeRespHeader := protocol.CommonHeader(decodeRespHeader(s.response.Header))
 		// save response code in context
 		if status, exist := decodeRespHeader.Get(types.HeaderStatus); exist {
-			s.context = context.WithValue(s.context, types.ContextKeyStatusCode, status)
+			decodeRespHeader.Set(protocol.MosnResponseStatusCode, status)
 		}
 
 		s.receiver.OnReceiveHeaders(s.context, decodeRespHeader, false)

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -36,7 +36,6 @@ const (
 	ContextKeyAcceptBuffer                ContextKey = "ContextKeyAcceptBuffer"
 	ContextKeyConnectionFd                ContextKey = "ConnectionFd"
 	ContextSubProtocol                    ContextKey = "ContextSubProtocol"
-	ContextKeyStatusCode                  ContextKey = "StatusCode"
 )
 
 // GlobalProxyName represents proxy name for metrics

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -36,6 +36,7 @@ const (
 	ContextKeyAcceptBuffer                ContextKey = "ContextKeyAcceptBuffer"
 	ContextKeyConnectionFd                ContextKey = "ConnectionFd"
 	ContextSubProtocol                    ContextKey = "ContextSubProtocol"
+	ContextKeyStatusCode                  ContextKey = "StatusCode"
 )
 
 // GlobalProxyName represents proxy name for metrics

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -90,6 +90,9 @@ type RequestInfo interface {
 	// ResponseCode reports the request's response code
 	ResponseCode() uint32
 
+	// SetResponseCode set request's response code
+	SetResponseCode(code uint32)
+
 	// Duration reports the duration since request's starting time
 	Duration() time.Duration
 


### PR DESCRIPTION
### Issues associated with this PR

 #349, add SetResponseCode function in RequestInfo interface

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
add SetResponseCode function, in downstream onUpstreamHeaders SetResponseCode from header

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
