### PR TITLE
chore: use default const value to replace magic number in config/parser

### DIFF
--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -41,6 +41,13 @@ var protocolsSupported = map[string]bool{
 	string(protocol.Xprotocol): true,
 }
 
+const (
+	MinHostWeight               = uint32(1)
+	MaxHostWeight               = uint32(128)
+	DefaultMaxRequestPerConn    = uint32(1024)
+	DefaultConnBufferLimitBytes = uint32(16 * 1024)
+)
+
 // RegisterProtocolParser
 // used to register parser
 func RegisterProtocolParser(key string) bool {
@@ -89,12 +96,14 @@ func ParseClusterConfig(clusters []v2.Cluster) ([]v2.Cluster, map[string][]v2.Ho
 			log.StartLogger.Fatalln("[name] is required in cluster config")
 		}
 		if c.MaxRequestPerConn == 0 {
-			c.MaxRequestPerConn = 1024
-			log.StartLogger.Infof("[max_request_per_conn] is not specified, use default value %d", 1024)
+			c.MaxRequestPerConn = DefaultMaxRequestPerConn
+			log.StartLogger.Infof("[max_request_per_conn] is not specified, use default value %d",
+				DefaultMaxRequestPerConn)
 		}
 		if c.ConnBufferLimitBytes == 0 {
-			c.ConnBufferLimitBytes = 16 * 1026
-			log.StartLogger.Infof("[conn_buffer_limit_bytes] is not specified, use default value %d", 1024*16)
+			c.ConnBufferLimitBytes = DefaultConnBufferLimitBytes
+			log.StartLogger.Infof("[conn_buffer_limit_bytes] is not specified, use default value %d",
+				DefaultConnBufferLimitBytes)
 		}
 		if c.LBSubSetConfig.FallBackPolicy > 2 {
 			log.StartLogger.Fatalln("lb subset config 's fall back policy set error. ",
@@ -125,11 +134,6 @@ func parseHostConfig(hosts []v2.Host) (hs []v2.Host) {
 	}
 	return
 }
-
-const (
-	MinHostWeight = uint32(1)
-	MaxHostWeight = uint32(128)
-)
 
 func transHostWeight(weight uint32) uint32 {
 	if weight > MaxHostWeight {
@@ -264,7 +268,8 @@ func ParseFaultInjectFilter(cfg map[string]interface{}) *v2.FaultInject {
 func ParseMixerFilter(cfg map[string]interface{}) *v2.Mixer {
 	mixerFilter := &v2.Mixer{}
 
-	data, err := json.Marshal(cfg); if err != nil {
+	data, err := json.Marshal(cfg)
+	if err != nil {
 		log.StartLogger.Errorf("parsing mixer filter error, err: %v, cfg: %v", err, cfg)
 		return nil
 	}

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -210,6 +210,15 @@ func TestParseClusterConfig(t *testing.T) {
 		t.Error("no callback")
 	}
 
+	if c.MaxRequestPerConn != DefaultMaxRequestPerConn {
+		t.Errorf("Expect cluster.MaxRequestPerConn default value %d but got %d",
+			DefaultMaxRequestPerConn, c.MaxRequestPerConn)
+	}
+
+	if c.ConnBufferLimitBytes != DefaultConnBufferLimitBytes {
+		t.Errorf("Expect cluster.ConnBufferLimitBytes default value%d, but got %d",
+			DefaultConnBufferLimitBytes, c.ConnBufferLimitBytes)
+	}
 }
 func TestParseListenerConfig(t *testing.T) {
 	// test listener inherit replace exists


### PR DESCRIPTION
### Issues associated with this PR

It no needs. The PR is  tiny changes which change some typo and magic number to const default value

### Sign the CLA
Yes

### Solutions
You should show your solutions about the issues in your PR, including the overall solutions, 
details and the changes. At this time, Chinese is allowed to describe these.

### UT result
N/A

### Benchmark
N/A

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
