### PR TITLE
feature: allow append duplicate listener in the same connection

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -681,47 +681,15 @@ func (c *connection) SetRemoteAddr(address net.Addr) {
 }
 
 func (c *connection) AddConnectionEventListener(cb types.ConnectionEventListener) {
-	exist := false
-
-	for _, ccb := range c.connCallbacks {
-		if &ccb == &cb {
-			exist = true
-			c.logger.Debugf("AddConnectionEventListener Failed, %+v Already Exist", cb)
-		}
-	}
-
-	if !exist {
-		c.logger.Debugf("AddConnectionEventListener Success, cb = %+v", cb)
-		c.connCallbacks = append(c.connCallbacks, cb)
-	}
+	c.connCallbacks = append(c.connCallbacks, cb)
 }
 
 func (c *connection) AddBytesReadListener(cb func(bytesRead uint64)) {
-	exist := false
-
-	for _, brcb := range c.bytesReadCallbacks {
-		if &brcb == &cb {
-			exist = true
-		}
-	}
-
-	if !exist {
-		c.bytesReadCallbacks = append(c.bytesReadCallbacks, cb)
-	}
+	c.bytesReadCallbacks = append(c.bytesReadCallbacks, cb)
 }
 
 func (c *connection) AddBytesSentListener(cb func(bytesSent uint64)) {
-	exist := false
-
-	for _, bscb := range c.bytesSendCallbacks {
-		if &bscb == &cb {
-			exist = true
-		}
-	}
-
-	if !exist {
-		c.bytesSendCallbacks = append(c.bytesSendCallbacks, cb)
-	}
+	c.bytesSendCallbacks = append(c.bytesSendCallbacks, cb)
 }
 
 func (c *connection) NextProtocol() string {

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/alipay/sofa-mosn/pkg/log"
@@ -11,10 +10,6 @@ import (
 type MyEventListener struct{}
 
 func (el *MyEventListener) OnEvent(event types.ConnectionEvent) {}
-
-func randN() int {
-	return rand.Intn(1024) + 1
-}
 
 func TestAddConnectionEventListener(t *testing.T) {
 	logger, err := log.NewLogger("stdout", log.INFO)
@@ -26,7 +21,7 @@ func TestAddConnectionEventListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := randN()
+	n := 1024
 	for i := 0; i < n; i++ {
 		el0 := &MyEventListener{}
 		c.AddConnectionEventListener(el0)
@@ -47,7 +42,7 @@ func TestAddBytesReadListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := randN()
+	n := 1024
 	for i := 0; i < n; i++ {
 		fn1 := func(bytesRead uint64) {}
 		c.AddBytesReadListener(fn1)
@@ -68,7 +63,7 @@ func TestAddBytesSendListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := randN()
+	n := 1024
 	for i := 0; i < n; i++ {
 		fn1 := func(bytesSent uint64) {}
 		c.AddBytesSentListener(fn1)

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -18,6 +18,7 @@
 package network
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/alipay/sofa-mosn/pkg/log"
@@ -28,7 +29,7 @@ type MyEventListener struct{}
 
 func (el *MyEventListener) OnEvent(event types.ConnectionEvent) {}
 
-func TestAddConnectionEventListener(t *testing.T) {
+func testAddConnectionEventListener(n int, t *testing.T) {
 	logger, err := log.NewLogger("stdout", log.INFO)
 	if err != nil {
 		t.Fatal(err)
@@ -38,7 +39,6 @@ func TestAddConnectionEventListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := 1024
 	for i := 0; i < n; i++ {
 		el0 := &MyEventListener{}
 		c.AddConnectionEventListener(el0)
@@ -49,7 +49,7 @@ func TestAddConnectionEventListener(t *testing.T) {
 	}
 }
 
-func TestAddBytesReadListener(t *testing.T) {
+func testAddBytesReadListener(n int, t *testing.T) {
 	logger, err := log.NewLogger("stdout", log.INFO)
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +59,6 @@ func TestAddBytesReadListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := 1024
 	for i := 0; i < n; i++ {
 		fn1 := func(bytesRead uint64) {}
 		c.AddBytesReadListener(fn1)
@@ -70,7 +69,7 @@ func TestAddBytesReadListener(t *testing.T) {
 	}
 }
 
-func TestAddBytesSendListener(t *testing.T) {
+func testAddBytesSendListener(n int, t *testing.T) {
 	logger, err := log.NewLogger("stdout", log.INFO)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +79,6 @@ func TestAddBytesSendListener(t *testing.T) {
 		logger: logger,
 	}
 
-	n := 1024
 	for i := 0; i < n; i++ {
 		fn1 := func(bytesSent uint64) {}
 		c.AddBytesSentListener(fn1)
@@ -88,5 +86,32 @@ func TestAddBytesSendListener(t *testing.T) {
 
 	if len(c.bytesSendCallbacks) != n {
 		t.Errorf("Expect %d, but got %d after AddBytesSentListener(fn1)", n, len(c.bytesSendCallbacks))
+	}
+}
+
+func TestAddConnectionEventListener(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		name := fmt.Sprintf("AddConnectionEventListener(%d)", i)
+		t.Run(name, func(t *testing.T) {
+			testAddConnectionEventListener(i, t)
+		})
+	}
+}
+
+func TestAddBytesReadListener(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		name := fmt.Sprintf("AddBytesReadListener(%d)", i)
+		t.Run(name, func(t *testing.T) {
+			testAddBytesReadListener(i, t)
+		})
+	}
+}
+
+func TestAddBytesSendListener(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		name := fmt.Sprintf("AddBytesSendListener(%d)", i)
+		t.Run(name, func(t *testing.T) {
+			testAddBytesSendListener(i, t)
+		})
 	}
 }

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package network
 
 import (

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/log"
+	"github.com/alipay/sofa-mosn/pkg/types"
+)
+
+type MyEventListener struct{}
+
+func (el *MyEventListener) OnEvent(event types.ConnectionEvent) {}
+
+func randN() int {
+	return rand.Intn(1024) + 1
+}
+
+func TestAddConnectionEventListener(t *testing.T) {
+	logger, err := log.NewLogger("stdout", log.INFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := connection{
+		logger: logger,
+	}
+
+	n := randN()
+	for i := 0; i < n; i++ {
+		el0 := &MyEventListener{}
+		c.AddConnectionEventListener(el0)
+	}
+
+	if len(c.connCallbacks) != n {
+		t.Errorf("Expect %d, but got %d after AddConnectionEventListener(el0)", n, len(c.connCallbacks))
+	}
+}
+
+func TestAddBytesReadListener(t *testing.T) {
+	logger, err := log.NewLogger("stdout", log.INFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := connection{
+		logger: logger,
+	}
+
+	n := randN()
+	for i := 0; i < n; i++ {
+		fn1 := func(bytesRead uint64) {}
+		c.AddBytesReadListener(fn1)
+	}
+
+	if len(c.bytesReadCallbacks) != n {
+		t.Errorf("Expect %d, but got %d after AddBytesReadListener(fn1)", n, len(c.bytesReadCallbacks))
+	}
+}
+
+func TestAddBytesSendListener(t *testing.T) {
+	logger, err := log.NewLogger("stdout", log.INFO)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := connection{
+		logger: logger,
+	}
+
+	n := randN()
+	for i := 0; i < n; i++ {
+		fn1 := func(bytesSent uint64) {}
+		c.AddBytesSentListener(fn1)
+	}
+
+	if len(c.bytesSendCallbacks) != n {
+		t.Errorf("Expect %d, but got %d after AddBytesSentListener(fn1)", n, len(c.bytesSendCallbacks))
+	}
+}

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package network
 
 import (


### PR DESCRIPTION
### Issues associated with this PR

Try to fix #359

### Sign the CLA
Yes

### Solutions

The Interface is comparable and if they have identical dynamic types and equal dynamic values or if both have value nil. But the function value cannot compare. So It's hard to guarantee the same behavior between `AddConnectionEventListener` 、 `TestAddBytesReadListener` and `TestAddBytesSendListener`

IMHO, Allowing duplicate listener in the same connection is okay and the caller should know what they do.

## UT result
````bash
❯ go test -v ./pkg/network/...                                                                                                                         
=== RUN   TestAddConnectionEventListener
--- PASS: TestAddConnectionEventListener (0.00s)
=== RUN   TestAddBytesReadListener
--- PASS: TestAddBytesReadListener (0.00s)
=== RUN   TestAddBytesSendListener
--- PASS: TestAddBytesSendListener (0.00s)
PASS
ok  	github.com/alipay/sofa-mosn/pkg/network	0.022s
````

### Benchmark
N/A

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
