### PR TITLE
workpool: remove the unused field (sync.Mutex)

### DIFF
--- a/pkg/sync/workerpool.go
+++ b/pkg/sync/workerpool.go
@@ -40,7 +40,6 @@ type shard struct {
 }
 
 type shardWorkerPool struct {
-	sync.Mutex
 	// workerFunc should never exit, always try to acquire jobs from jobs channel
 	workerFunc WorkerFunc
 	shards     []*shard


### PR DESCRIPTION
### Issues associated with this PR

remove the unused field (sync.Mutex) in shardWorkerPool

### Sign the CLA
Yes

### Solutions
N/A

## UT result
N/A

### Benchmark
N/A

### Code Style
N/A
