### PR TITLE
buffer: cover IoBuffer ByteBufferPool tests and fix minor bug

### DIFF
--- a/pkg/buffer/bytebufferpool_test.go
+++ b/pkg/buffer/bytebufferpool_test.go
@@ -1,0 +1,67 @@
+package buffer
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func intRange(min, max int) int {
+	return rand.Intn(max-min) + min
+}
+
+func intN(n int) int {
+	return rand.Intn(n) + 1
+}
+
+func TestByteBufferPoolSmallBytes(t *testing.T) {
+	pool := newByteBufferPool()
+
+	for i := 0; i < 1024; i++ {
+		size := intN(1 << minShift)
+		ob := pool.take(size)
+		// Puts the bytes to pool
+		pool.give(ob)
+
+		nb := pool.take(size)
+		if nb == ob {
+			t.Errorf("Expect get the different bytes from pool, but got %p %p", nb, ob)
+		}
+	}
+}
+
+func TestBytesBufferPoolMediumBytes(t *testing.T) {
+	pool := newByteBufferPool()
+
+	for i := 0; i < 1024; i++ {
+		size := intRange(1<<minShift+1, 1<<maxShift)
+		ob := pool.take(size)
+		// Puts the bytes to pool
+		pool.give(ob)
+
+		nb := pool.take(size)
+		if nb != ob {
+			t.Errorf("Expect get the same bytes from pool, but got %p %p", nb, ob)
+		}
+	}
+}
+
+func TestBytesBufferPoolLargeBytes(t *testing.T) {
+	pool := newByteBufferPool()
+
+	for i := 0; i < 1024; i++ {
+		size := 1<<maxShift + intN(i+1)
+		ob := pool.take(size)
+		// Puts the bytes to pool
+		pool.give(ob)
+
+		nb := pool.take(size)
+		if nb == ob {
+			t.Errorf("Expect get the different bytes from pool, but got %p %p", nb, ob)
+		}
+	}
+}

--- a/pkg/buffer/bytebufferpool_test.go
+++ b/pkg/buffer/bytebufferpool_test.go
@@ -23,30 +23,30 @@ func TestByteBufferPoolSmallBytes(t *testing.T) {
 
 	for i := 0; i < 1024; i++ {
 		size := intN(1 << minShift)
-		ob := pool.take(size)
-		// Puts the bytes to pool
-		pool.give(ob)
+		bp := pool.take(size)
 
-		nb := pool.take(size)
-		if nb == ob {
-			t.Errorf("Expect get the different bytes from pool, but got %p %p", nb, ob)
+		if cap(*bp) != size {
+			t.Errorf("Expect get the %d bytes from pool, but got %d", size, cap(*bp))
 		}
+
+		// Puts the bytes to pool
+		pool.give(bp)
 	}
 }
 
 func TestBytesBufferPoolMediumBytes(t *testing.T) {
 	pool := newByteBufferPool()
 
-	for i := 0; i < 1024; i++ {
-		size := intRange(1<<minShift+1, 1<<maxShift)
-		ob := pool.take(size)
-		// Puts the bytes to pool
-		pool.give(ob)
+	for i := minShift; i < maxShift; i++ {
+		size := intRange(1 << uint(i), 1 << uint(i+1))
+		bp := pool.take(size)
 
-		nb := pool.take(size)
-		if nb != ob {
-			t.Errorf("Expect get the same bytes from pool, but got %p %p", nb, ob)
+		if cap(*bp) != 1 << uint(i+1) {
+			t.Errorf("Expect get the slab size (%d) from pool, but got %d", 1 << uint(i+1), cap(*bp))
 		}
+
+		//Puts the bytes to pool
+		pool.give(bp)
 	}
 }
 
@@ -55,13 +55,13 @@ func TestBytesBufferPoolLargeBytes(t *testing.T) {
 
 	for i := 0; i < 1024; i++ {
 		size := 1<<maxShift + intN(i+1)
-		ob := pool.take(size)
-		// Puts the bytes to pool
-		pool.give(ob)
+		bp := pool.take(size)
 
-		nb := pool.take(size)
-		if nb == ob {
-			t.Errorf("Expect get the different bytes from pool, but got %p %p", nb, ob)
+		if cap(*bp) != size {
+			t.Errorf("Expect get the %d bytes from pool, but got %d", size, cap(*bp))
 		}
+
+		// Puts the bytes to pool
+		pool.give(bp)
 	}
 }

--- a/pkg/buffer/iobuffer.go
+++ b/pkg/buffer/iobuffer.go
@@ -282,9 +282,7 @@ func (b *IoBuffer) Append(data []byte) error {
 }
 
 func (b *IoBuffer) AppendByte(data byte) error {
-	datas := makeSlice(1)
-	return b.Append(datas)
-
+	return b.Append([]byte{data})
 }
 
 func (b *IoBuffer) Peek(n int) []byte {

--- a/pkg/buffer/iobuffer.go
+++ b/pkg/buffer/iobuffer.go
@@ -67,8 +67,13 @@ func (b *IoBuffer) Read(p []byte) (n int, err error) {
 }
 
 func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, err error) {
-	var conn net.Conn
-	var loop, ok, first = true, true, true
+	var (
+		m               int
+		e               error
+		zeroTime        time.Time
+		conn            net.Conn
+		loop, ok, first = true, true, true
+	)
 
 	if conn, ok = r.(net.Conn); !ok {
 		loop = false
@@ -98,15 +103,21 @@ func (b *IoBuffer) ReadOnce(r io.Reader) (n int64, err error) {
 
 		l := cap(b.buf) - len(b.buf)
 
-		if first {
-			conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if conn != nil {
+			if first {
+				conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			} else {
+				conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+			}
+
+			m, e = r.Read(b.buf[len(b.buf):cap(b.buf)])
+
+			// Reset read deadline
+			conn.SetReadDeadline(zeroTime)
+
 		} else {
-			conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+			m, e = r.Read(b.buf[len(b.buf):cap(b.buf)])
 		}
-
-		m, e := r.Read(b.buf[len(b.buf):cap(b.buf)])
-
-		conn.SetReadDeadline(time.Time{})
 
 		if e != nil {
 			return n, e

--- a/pkg/buffer/iobuffer_test.go
+++ b/pkg/buffer/iobuffer_test.go
@@ -1,0 +1,259 @@
+package buffer
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func randString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func randN(n int) int {
+	return rand.Intn(n) + 1
+}
+
+func TestNewIoBufferString(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		s := randString(i)
+		b := NewIoBufferString(s)
+		if b.String() != s {
+			t.Errorf("Expect %s but got %s", s, b.String())
+		}
+	}
+}
+
+func TestNewIoBufferBytes(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		s := randString(i)
+		b := NewIoBufferBytes([]byte(s))
+		if !bytes.Equal(b.Bytes(), []byte(s)) {
+			t.Errorf("Expect %s but got %s", s, b.String())
+		}
+	}
+}
+
+func TestIoBufferCopy(t *testing.T) {
+	bi := NewIoBuffer(1)
+	b := bi.(*IoBuffer)
+	n := randN(1024) + 1
+	b.copy(n)
+	if cap(b.buf) < 2*1+n {
+		t.Errorf("b.copy(%d) should expand to at least %d, but got %d", n, 2*1+n, cap(b.buf))
+	}
+}
+
+func TestIoBufferWrite(t *testing.T) {
+	b := NewIoBuffer(1)
+	n := randN(64)
+
+	for i := 0; i < n; i++ {
+		s := randString(i + 16)
+		n, err := b.Write([]byte(s))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n != len(s) {
+			t.Errorf("Expect write %d bytes, but got %d", len(s), n)
+		}
+
+		if !bytes.Equal(b.Peek(len(s)), []byte(s)) {
+			t.Errorf("Expect peek %s but got %s", s, string(b.Peek(len(s))))
+		}
+
+		b.Drain(len(s))
+	}
+
+	input := make([]byte, 0, 1024)
+	writer := bytes.NewBuffer(nil)
+
+	for i := 0; i < n; i++ {
+		s := randString(i + 16)
+		n, err := b.Write([]byte(s))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if n != len(s) {
+			t.Errorf("Expect write %d bytes, but got %d", len(s), n)
+		}
+
+		input = append(input, []byte(s)...)
+	}
+
+	_, err := b.WriteTo(writer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(writer.Bytes(), input) {
+		t.Errorf("Expect %s but got %s", input, string(writer.Bytes()))
+	}
+}
+
+func TestIoBufferAppend(t *testing.T) {
+	bi := NewIoBuffer(1)
+	b := bi.(*IoBuffer)
+	n := randN(64)
+	for i := 0; i < n; i++ {
+		s := randString(i + 16)
+		err := b.Append([]byte(s))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(b.Peek(len(s)), []byte(s)) {
+			t.Errorf("Expect peek %s but got %s", s, string(b.Peek(len(s))))
+		}
+
+		b.Drain(len(s))
+	}
+}
+
+func TestIoBufferAppendByte(t *testing.T) {
+	bi := NewIoBuffer(1)
+	b := bi.(*IoBuffer)
+	input := make([]byte, 0, 1024)
+	n := randN(1024)
+
+	for i := 0; i < n; i++ {
+		err := b.AppendByte(byte(i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		input = append(input, byte(i))
+	}
+
+	if b.Len() != n {
+		t.Errorf("Expect %d bytes, but got %d", n, b.Len())
+	}
+
+	if !bytes.Equal(b.Peek(n), input) {
+		t.Errorf("Expect %x, but got %x", input, b.Peek(n))
+	}
+}
+
+func TestIoBufferRead(t *testing.T) {
+	b := NewIoBuffer(0)
+	data := make([]byte, 1)
+
+	n, err := b.Read(data)
+	if err != io.EOF {
+		t.Errorf("Expect io.EOF but got %s", err)
+	}
+
+	if n != 0 {
+		t.Errorf("Expect 0 bytes but got %d", n)
+	}
+
+	n, err = b.Read(nil)
+	if n != 0 || err != nil {
+		t.Errorf("Expect (0, nil) but got (%d, %s)", n, err)
+	}
+
+	b = NewIoBuffer(1)
+	s := randString(1024)
+	reader := bytes.NewReader([]byte(s))
+
+	nr, err := b.ReadFrom(reader)
+	if err != nil {
+		t.Errorf("Expect nil but got %s", err)
+	}
+
+	if nr != int64(len(s)) {
+		t.Errorf("Expect %d bytes but got %d", len(s), nr)
+	}
+
+	if !bytes.Equal(b.Peek(len(s)), []byte(s)) {
+		t.Errorf("Expect peek %s but got %s", s, string(b.Peek(len(s))))
+	}
+}
+
+func TestIoBufferReadOnce(t *testing.T) {
+	b := NewIoBuffer(1)
+	s := randString(1024)
+	input := make([]byte, 0, 1024)
+	reader := bytes.NewReader([]byte(s))
+
+	for {
+		n, err := b.ReadOnce(reader)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+
+		if n != 1 {
+			t.Errorf("Expect %d bytes but got %d", len(s), n)
+		}
+
+		input = append(input, b.Peek(int(n))...)
+		b.Drain(int(n))
+	}
+
+	if !bytes.Equal(input, []byte(s)) {
+		t.Errorf("Expect got %s but got %s", s, string(input))
+	}
+}
+
+func TestIoBufferClone(t *testing.T) {
+	for i := 16; i < 1024+16; i++ {
+		s := randString(i)
+		buffer := NewIoBufferString(s)
+		nb := buffer.Clone()
+		if nb.String() != s {
+			t.Errorf("Clone() expect %s but got %s", s, nb.String())
+		}
+	}
+}
+
+func TestIoBufferCut(t *testing.T) {
+	for i := 16; i < 1024+16; i++ {
+		s := randString(i)
+		bi := NewIoBufferString(s)
+		b := bi.(*IoBuffer)
+		offset := randN(i) - 1
+		nb := b.Cut(offset)
+		if nb.String() != s[:offset] {
+			t.Errorf("Cut(%d) expect %s but got %s", offset, s[:offset], nb.String())
+		}
+	}
+}
+
+func TestIoBufferAllocAndFree(t *testing.T) {
+	b := NewIoBuffer(0)
+	for i := 0; i < 1024; i++ {
+		b.Alloc(i)
+		if b.Cap() < i {
+			t.Errorf("Expect alloc at least %d bytes but allocated %d", i, b.Cap())
+		}
+	}
+
+	b.Reset()
+
+	for i := 0; i < 1024; i++ {
+		b.Alloc(i)
+		if b.Cap() < i {
+			t.Errorf("Expect alloc at least %d bytes but allocated %d", i, b.Cap())
+		}
+		b.Free()
+		if b.Cap() != 0 {
+			t.Errorf("Expect free to 0 bytes but got %d", b.Cap())
+		}
+	}
+}


### PR DESCRIPTION
The PR does something like the following:

1. cover IoBuffer tests
2. cover BytesBufferPool tests
3. fix `IoBuffer.ReadOnce` panic when the reader is not `net.Conn`
4. fix `Iobuffer.AppendByte`

### Issues associated with this PR

No issues.

### Sign the CLA
Yes

### UT
````bash
❯ go test -v ./pkg/buffer/...                                                                                                                  

=== RUN   Test_IoBufferPool
--- PASS: Test_IoBufferPool (0.00s)
    buffer_test.go:117: IoBufferPool Test Sucess
=== RUN   Test_IoBufferPool_Slice_Increase
--- PASS: Test_IoBufferPool_Slice_Increase (0.00s)
    buffer_test.go:138: IoBufferPool Test Slice Increase Sucess
=== RUN   Test_IoBufferPool_Alloc_Free
--- PASS: Test_IoBufferPool_Alloc_Free (0.00s)
    buffer_test.go:160: IoBufferPool Test Alloc Free Sucess
=== RUN   Test_ByteBufferPool
--- PASS: Test_ByteBufferPool (0.00s)
    buffer_test.go:182: ByteBufferPool Test Sucess
=== RUN   TestByteBufferPoolSmallBytes
--- PASS: TestByteBufferPoolSmallBytes (0.00s)
=== RUN   TestBytesBufferPoolMediumBytes
--- PASS: TestBytesBufferPoolMediumBytes (0.00s)
=== RUN   TestBytesBufferPoolLargeBytes
--- PASS: TestBytesBufferPoolLargeBytes (0.00s)
=== RUN   TestNewIoBufferString
--- PASS: TestNewIoBufferString (0.00s)
=== RUN   TestNewIoBufferBytes
--- PASS: TestNewIoBufferBytes (0.01s)
=== RUN   TestIoBufferCopy
--- PASS: TestIoBufferCopy (0.00s)
=== RUN   TestIoBufferWrite
--- PASS: TestIoBufferWrite (0.00s)
=== RUN   TestIoBufferAppend
--- PASS: TestIoBufferAppend (0.00s)
=== RUN   TestIoBufferAppendByte
--- PASS: TestIoBufferAppendByte (0.00s)
=== RUN   TestIoBufferRead
--- PASS: TestIoBufferRead (0.00s)
=== RUN   TestIoBufferReadOnce
--- PASS: TestIoBufferReadOnce (0.00s)
=== RUN   TestIoBufferClone
--- PASS: TestIoBufferClone (0.00s)
=== RUN   TestIoBufferCut
--- PASS: TestIoBufferCut (0.00s)
=== RUN   TestIoBufferAllocAndFree
--- PASS: TestIoBufferAllocAndFree (0.00s)
=== RUN   TestIoBufferPoolWithCount
--- PASS: TestIoBufferPoolWithCount (0.00s)
PASS
ok  	github.com/alipay/sofa-mosn/pkg/buffer	0.034s
````

### Benchmark
N/A

### Code Style
N/A