### PR TITLE
bugfix: avoid memory leak in downstream (http1 or http2)

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -461,7 +461,7 @@ func (al *activeListener) OnNewConnection(ctx context.Context, conn types.Connec
 	// and we can return directly.
 	if al.disableConnIo {
 		atomic.AddInt64(&al.handler.numConnections, -1)
-		al.logger.Debugf("new downstream connection %d closed", conn.ID())
+		al.logger.Debugf("downstream connection %d was closed", conn.ID())
 		return
 	}
 

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -454,7 +454,11 @@ func (al *activeListener) OnNewConnection(ctx context.Context, conn types.Connec
 		return
 	}
 
-	// todo: this hack is due to http2 protocol process. golang http2 provides a io loop to read/write stream
+	// TODO(detailyang): bind the close|reset event to OnEvent
+	// Since the fasthttp and http2 will hijack the io loop.
+	// We have no chance to bind the close|reset event to our event callback.
+	// We could think when we yield from the fasthttp and http2 io loop, the connection is finalized
+	// and we can return directly.
 	if al.disableConnIo {
 		atomic.AddInt64(&al.handler.numConnections, -1)
 		al.logger.Debugf("new downstream connection %d closed", conn.ID())

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -356,12 +356,12 @@ func newActiveListener(listener types.Listener, lc *v2.Listener, logger log.Logg
 		listener:                listener,
 		networkFiltersFactories: networkFiltersFactories,
 		streamFiltersFactories:  streamFiltersFactories,
-		conns:                   list.New(),
-		handler:                 handler,
-		stopChan:                stopChan,
-		logger:                  logger,
-		accessLogs:              accessLoggers,
-		updatedLabel:            false,
+		conns:        list.New(),
+		handler:      handler,
+		stopChan:     stopChan,
+		logger:       logger,
+		accessLogs:   accessLoggers,
+		updatedLabel: false,
 	}
 
 	listenPort := 0

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -356,12 +356,12 @@ func newActiveListener(listener types.Listener, lc *v2.Listener, logger log.Logg
 		listener:                listener,
 		networkFiltersFactories: networkFiltersFactories,
 		streamFiltersFactories:  streamFiltersFactories,
-		conns:        list.New(),
-		handler:      handler,
-		stopChan:     stopChan,
-		logger:       logger,
-		accessLogs:   accessLoggers,
-		updatedLabel: false,
+		conns:                   list.New(),
+		handler:                 handler,
+		stopChan:                stopChan,
+		logger:                  logger,
+		accessLogs:              accessLoggers,
+		updatedLabel:            false,
 	}
 
 	listenPort := 0


### PR DESCRIPTION
### Issues associated with this PR

Try to fix #379 

### Sign the CLA
Yes

### Solutions
Since the fasthttp and http2 will hijack the io loop. We have no chance to bind the close|reset event to our event callback. We could think when we yield from the fasthttp and http2 io loop, the connection is finalized and we can return directly and reduce the number of connections.

### UT result
N/A

### Benchmark
N/A

### Code Style
N/A
