### PR TITLE
optimize handler chain

### DIFF
--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -57,21 +57,21 @@ type simpleHandler struct {
 	route types.Route
 }
 
-func (h *simpleHandler) IsAvailable(ctx context.Context) bool {
-	return true
+func (h *simpleHandler) IsAvailable(ctx context.Context, snapshot types.ClusterSnapshot) types.HandlerStatus {
+	return types.HandlerAvailable
 }
 func (h *simpleHandler) Route() types.Route {
 	return h.route
 }
-func DefaultMakeHandlerChain(headers types.HeaderMap, routers types.Routers) *RouteHandlerChain {
+func DefaultMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {
 	if r := routers.Route(headers, 1); r != nil {
-		return NewRouteHandlerChain(context.Background(), []types.RouteHandler{
+		return NewRouteHandlerChain(context.Background(), clusterManager, []types.RouteHandler{
 			&simpleHandler{route: r},
 		})
 	}
 	return nil
 }
 
-func CallMakeHandlerChain(headers types.HeaderMap, routers types.Routers) *RouteHandlerChain {
-	return makeHandlerChain(headers, routers)
+func CallMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {
+	return makeHandlerChain(headers, routers, clusterManager)
 }

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -60,9 +60,11 @@ type simpleHandler struct {
 func (h *simpleHandler) IsAvailable(ctx context.Context, snapshot types.ClusterSnapshot) types.HandlerStatus {
 	return types.HandlerAvailable
 }
+
 func (h *simpleHandler) Route() types.Route {
 	return h.route
 }
+
 func DefaultMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {
 	if r := routers.Route(headers, 1); r != nil {
 		return NewRouteHandlerChain(context.Background(), clusterManager, []types.RouteHandler{

--- a/pkg/router/handlerchain.go
+++ b/pkg/router/handlerchain.go
@@ -29,26 +29,39 @@ func init() {
 
 // RouteHandlerChain returns first available handler's router
 type RouteHandlerChain struct {
-	ctx      context.Context
-	handlers []types.RouteHandler
-	index    int
+	ctx            context.Context
+	handlers       []types.RouteHandler
+	clusterManager types.ClusterManager
+	index          int
 }
 
-func NewRouteHandlerChain(ctx context.Context, handlers []types.RouteHandler) *RouteHandlerChain {
+func NewRouteHandlerChain(ctx context.Context, clusterManager types.ClusterManager, handlers []types.RouteHandler) *RouteHandlerChain {
 	return &RouteHandlerChain{
-		ctx:      ctx,
-		handlers: handlers,
-		index:    0,
+		ctx:            ctx,
+		handlers:       handlers,
+		clusterManager: clusterManager,
+		index:          0,
 	}
 }
 
-func (hc *RouteHandlerChain) DoNextHandler() types.Route {
+func (hc *RouteHandlerChain) DoNextHandler() (types.ClusterSnapshot, types.Route) {
 	handler := hc.Next()
 	if handler == nil {
-		return nil
+		return nil, nil
 	}
-	if handler.IsAvailable(hc.ctx) {
-		return handler.Route()
+	clusterName := handler.Route().RouteRule().ClusterName()
+	snapshot := hc.clusterManager.GetClusterSnapshot(context.Background(), clusterName)
+	status := handler.IsAvailable(hc.ctx, snapshot)
+	switch status {
+	case types.HandlerAvailable:
+		return snapshot, handler.Route()
+	case types.HandlerNotAvailable:
+		hc.clusterManager.PutClusterSnapshot(snapshot)
+		return hc.DoNextHandler()
+	case types.HandlerStop:
+		return nil, nil
+	default:
+		panic("unexpected handler status")
 	}
 	return hc.DoNextHandler()
 }

--- a/pkg/router/handlerchain.go
+++ b/pkg/router/handlerchain.go
@@ -20,6 +20,7 @@ package router
 import (
 	"context"
 
+	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
@@ -57,11 +58,10 @@ func (hc *RouteHandlerChain) DoNextHandler() (types.ClusterSnapshot, types.Route
 		return snapshot, handler.Route()
 	case types.HandlerNotAvailable:
 		hc.clusterManager.PutClusterSnapshot(snapshot)
-		return hc.DoNextHandler()
 	case types.HandlerStop:
 		return nil, nil
 	default:
-		panic("unexpected handler status")
+		log.DefaultLogger.Errorf("unexpected handler status, do next handler....")
 	}
 	return hc.DoNextHandler()
 }

--- a/pkg/router/handlerchain_test.go
+++ b/pkg/router/handlerchain_test.go
@@ -18,6 +18,7 @@
 package router
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -33,6 +34,18 @@ type mockRouter struct {
 	types.Route
 }
 
+func (r *mockRouter) RouteRule() types.RouteRule {
+	return &mockRouteRule{}
+}
+
+type mockRouteRule struct {
+	types.RouteRule
+}
+
+func (r *mockRouteRule) ClusterName() string {
+	return ""
+}
+
 func (routers *mockRouters) Route(headers types.HeaderMap, randomValue uint64) types.Route {
 	if reflect.DeepEqual(headers, routers.header) {
 		return routers.r[0]
@@ -44,6 +57,16 @@ func (routers *mockRouters) GetAllRoutes(headers types.HeaderMap, randomValue ui
 		return routers.r
 	}
 	return nil
+}
+
+type mockManager struct {
+	types.ClusterManager
+}
+
+func (m *mockManager) GetClusterSnapshot(ctx context.Context, name string) types.ClusterSnapshot {
+	return nil
+}
+func (m *mockManager) PutClusterSnapshot(snapshot types.ClusterSnapshot) {
 }
 
 func TestDefaultMakeHandlerChain(t *testing.T) {
@@ -58,17 +81,68 @@ func TestDefaultMakeHandlerChain(t *testing.T) {
 	}
 	//
 	makeHandlerChain = DefaultMakeHandlerChain
+	clusterManager := &mockManager{}
 	//
-	if hc := CallMakeHandlerChain(headerMatch, routers); hc == nil {
+	if hc := CallMakeHandlerChain(headerMatch, routers, clusterManager); hc == nil {
 		t.Fatal("make handler chain failed")
 	} else {
-		if r := hc.DoNextHandler(); r == nil {
+		if _, r := hc.DoNextHandler(); r == nil {
 			t.Fatal("do next handler failed")
 		}
 	}
 	headerNotMatch := protocol.CommonHeader(map[string]string{})
-	if hc := CallMakeHandlerChain(headerNotMatch, routers); hc != nil {
+	if hc := CallMakeHandlerChain(headerNotMatch, routers, clusterManager); hc != nil {
 		t.Fatal("make handler chain unexpected")
+	}
+
+}
+
+type mockStatusHandler struct {
+	status types.HandlerStatus
+}
+
+func (h *mockStatusHandler) IsAvailable(ctx context.Context, snapshot types.ClusterSnapshot) types.HandlerStatus {
+	return h.status
+}
+func (h *mockStatusHandler) Route() types.Route {
+	return &mockRouter{}
+}
+
+func _TestMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {
+	rs := routers.GetAllRoutes(headers, 1)
+	var handlers []types.RouteHandler
+	// NotAvailable is 1
+	// Stop is 2
+	for i := range rs {
+		handler := &mockStatusHandler{
+			status: types.HandlerStatus(i + 1),
+		}
+		handlers = append(handlers, handler)
+	}
+	return NewRouteHandlerChain(context.Background(), clusterManager, handlers)
+}
+
+func TestExtendHandler(t *testing.T) {
+	headerMatch := protocol.CommonHeader(map[string]string{
+		"test": "test",
+	})
+	routers := &mockRouters{
+		r: []types.Route{
+			&mockRouter{},
+			&mockRouter{},
+		},
+		header: headerMatch,
+	}
+	// register
+	makeHandlerChain = _TestMakeHandlerChain
+	clusterManager := &mockManager{}
+	//
+	if hc := CallMakeHandlerChain(headerMatch, routers, clusterManager); hc == nil {
+		t.Fatal("make extend handler chain failed")
+	} else {
+		if _, route := hc.DoNextHandler(); route != nil {
+			t.Fatal("unexpected Handler result")
+		}
 	}
 
 }

--- a/pkg/router/handlerchain_test.go
+++ b/pkg/router/handlerchain_test.go
@@ -162,6 +162,11 @@ func TestExtendHandler(t *testing.T) {
 	} else {
 		if _, route := hc.DoNextHandler(); route == nil {
 			t.Fatal("want to get a available router")
+		} else {
+			// verify the router
+			if route.(*mockRouter).status != types.HandlerAvailable {
+				t.Error("handler chain get router unexpected")
+			}
 		}
 	}
 	// Test HandlerChain: all of the handlers are NotAvailable

--- a/pkg/router/routeruleimpl.go
+++ b/pkg/router/routeruleimpl.go
@@ -132,11 +132,15 @@ func (rri *RouteRuleImplBase) GetRouterName() string {
 // types.Route
 func (rri *RouteRuleImplBase) RedirectRule() types.RedirectRule {
 
-	return rri.RedirectRule()
+	return nil
 }
 
 func (rri *RouteRuleImplBase) RouteRule() types.RouteRule {
 	return rri
+}
+
+func (rri *RouteRuleImplBase) PathMatchCriterion() types.PathMatchCriterion {
+	return nil
 }
 
 // types.RouteRule
@@ -301,6 +305,10 @@ type SofaRouteRuleImpl struct {
 	matchValue string
 }
 
+func (srri *SofaRouteRuleImpl) PathMatchCriterion() types.PathMatchCriterion {
+	return srri
+}
+
 func (srri *SofaRouteRuleImpl) Matcher() string {
 
 	return srri.matchValue
@@ -337,6 +345,10 @@ func (srri *SofaRouteRuleImpl) FinalizeRequestHeaders(headers types.HeaderMap, r
 type PathRouteRuleImpl struct {
 	*RouteRuleImplBase
 	path string
+}
+
+func (prri *PathRouteRuleImpl) PathMatchCriterion() types.PathMatchCriterion {
+	return prri
 }
 
 func (prri *PathRouteRuleImpl) Matcher() string {
@@ -388,6 +400,10 @@ type PrefixRouteRuleImpl struct {
 	prefix string
 }
 
+func (prei *PrefixRouteRuleImpl) PathMatchCriterion() types.PathMatchCriterion {
+	return prei
+}
+
 func (prei *PrefixRouteRuleImpl) Matcher() string {
 
 	return prei.prefix
@@ -429,6 +445,10 @@ type RegexRouteRuleImpl struct {
 	*RouteRuleImplBase
 	regexStr     string
 	regexPattern *regexp.Regexp
+}
+
+func (rrei *RegexRouteRuleImpl) PathMatchCriterion() types.PathMatchCriterion {
+	return rrei
 }
 
 func (rrei *RegexRouteRuleImpl) Matcher() string {

--- a/pkg/router/routeruleimpl_test.go
+++ b/pkg/router/routeruleimpl_test.go
@@ -63,9 +63,14 @@ func TestPrefixRouteRuleImpl(t *testing.T) {
 			route.Match.Prefix,
 		}
 		headers := protocol.CommonHeader(map[string]string{protocol.MosnHeaderPathKey: tc.headerpath})
-		result := rr.Match(headers, 1) != nil
-		if result != tc.expected {
+		result := rr.Match(headers, 1)
+		if (result != nil) != tc.expected {
 			t.Errorf("#%d want matched %v, but get matched %v\n", i, tc.expected, result)
+		}
+		if result != nil {
+			if result.RouteRule().PathMatchCriterion().MatchType() != types.Prefix {
+				t.Errorf("#%d match type is not expected", i)
+			}
 		}
 	}
 }
@@ -98,9 +103,14 @@ func TestPathRouteRuleImpl(t *testing.T) {
 		base.caseSensitive = tc.caseSensitive //hack case sensitive
 		rr := &PathRouteRuleImpl{base, route.Match.Path}
 		headers := protocol.CommonHeader(map[string]string{protocol.MosnHeaderPathKey: tc.headerpath})
-		result := rr.Match(headers, 1) != nil
-		if result != tc.expected {
+		result := rr.Match(headers, 1)
+		if (result != nil) != tc.expected {
 			t.Errorf("#%d want matched %v, but get matched %v\n", i, tc.expected, result)
+		}
+		if result != nil {
+			if result.RouteRule().PathMatchCriterion().MatchType() != types.Exact {
+				t.Errorf("#%d match type is not expected", i)
+			}
 		}
 
 	}
@@ -138,9 +148,14 @@ func TestRegexRouteRuleImpl(t *testing.T) {
 			re,
 		}
 		headers := protocol.CommonHeader(map[string]string{protocol.MosnHeaderPathKey: tc.headerpath})
-		result := rr.Match(headers, 1) != nil
-		if result != tc.expected {
+		result := rr.Match(headers, 1)
+		if (result != nil) != tc.expected {
 			t.Errorf("#%d want matched %v, but get matched %v\n", i, tc.expected, result)
+		}
+		if result != nil {
+			if result.RouteRule().PathMatchCriterion().MatchType() != types.Regex {
+				t.Errorf("#%d match type is not expected", i)
+			}
 		}
 	}
 }
@@ -615,48 +630,48 @@ func TestRouteRuleImplBase_UpdateMetaDataMatchCriteria(t *testing.T) {
 			name: "common case",
 			origin: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(originMetadatas[0].originMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(originMetadatas[0].originMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(originMetadatas[0].originMetadata),
 			},
 			updatedMetadata: updatedMetadatas[0].updatedMetadata,
 			want: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(updatedMetadatas[0].updatedMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(updatedMetadatas[0].updatedMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(updatedMetadatas[0].updatedMetadata),
 			},
 		},
 		{
 			name: "corner case1",
 			origin: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(originMetadatas[0].originMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(originMetadatas[0].originMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(originMetadatas[0].originMetadata),
 			},
 			updatedMetadata: updatedMetadatas[1].updatedMetadata,
 			want: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(updatedMetadatas[1].updatedMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(updatedMetadatas[1].updatedMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(updatedMetadatas[1].updatedMetadata),
 			},
 		},
 		{
 			name: "corner case2",
 			origin: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(originMetadatas[1].originMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(originMetadatas[1].originMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(originMetadatas[1].originMetadata),
 			},
 			updatedMetadata: updatedMetadatas[1].updatedMetadata,
 			want: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(updatedMetadatas[0].updatedMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(updatedMetadatas[0].updatedMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(updatedMetadatas[0].updatedMetadata),
 			},
 		},
 		{
 			name: "corner case3",
 			origin: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(originMetadatas[1].originMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(originMetadatas[1].originMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(originMetadatas[1].originMetadata),
 			},
 			updatedMetadata: updatedMetadatas[1].updatedMetadata,
 			want: &RouteRuleImplBase{
 				metadataMatchCriteria: NewMetadataMatchCriteriaImpl(updatedMetadatas[1].updatedMetadata),
-				metaData:              getClusterMosnLBMetaDataMap(updatedMetadatas[1].updatedMetadata),
+				metaData:              GetClusterMosnLBMetaDataMap(updatedMetadatas[1].updatedMetadata),
 			},
 		},
 	}

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -51,6 +51,7 @@ type info interface {
 type RouteBase interface {
 	types.Route
 	types.RouteRule
+	types.PathMatchCriterion
 	matchable
 	info
 }
@@ -201,4 +202,4 @@ func (p *routerPolicy) LoadBalancerPolicy() types.LoadBalancerPolicy {
 type RouterRuleFactory func(base *RouteRuleImplBase, header []v2.HeaderMatcher) RouteBase
 
 // MakeHandlerChain creates a RouteHandlerChain
-type MakeHandlerChain func(types.HeaderMap, types.Routers) *RouteHandlerChain
+type MakeHandlerChain func(types.HeaderMap, types.Routers, types.ClusterManager) *RouteHandlerChain

--- a/pkg/router/utility.go
+++ b/pkg/router/utility.go
@@ -25,6 +25,11 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
+// GetClusterMosnLBMetaDataMap exports getClusterMosnLBMetaDataMap
+func GetClusterMosnLBMetaDataMap(metadata v2.Metadata) types.RouteMetaData {
+	return getClusterMosnLBMetaDataMap(metadata)
+}
+
 // getClusterMosnLBMetaDataMap from v2.Metadata
 // Value maybe hashed
 func getClusterMosnLBMetaDataMap(metadata v2.Metadata) types.RouteMetaData {

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -56,9 +56,18 @@ type RouterManager interface {
 	GetRouterWrapperByName(routerConfigName string) RouterWrapper
 }
 
+// HandlerStatus returns the Handler's available status
+type HandlerStatus int
+
+const (
+	HandlerAvailable HandlerStatus = iota
+	HandlerNotAvailable
+	HandlerStop
+)
+
 // RouteHandler is an external check handler for a route
 type RouteHandler interface {
-	IsAvailable(context.Context) bool
+	IsAvailable(context.Context, ClusterSnapshot) HandlerStatus
 	Route() Route
 }
 type RouterWrapper interface {
@@ -111,6 +120,9 @@ type RouteRule interface {
 
 	// FinalizeResponseHeaders do potentially destructive header transforms on response headers prior to forwarding
 	FinalizeResponseHeaders(headers HeaderMap, requestInfo RequestInfo)
+
+	// PathMatchCriterion returns the route's PathMatchCriterion
+	PathMatchCriterion() PathMatchCriterion
 }
 
 // Policy defines a group of route policy

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -59,6 +59,7 @@ type RouterManager interface {
 // HandlerStatus returns the Handler's available status
 type HandlerStatus int
 
+// HandlerStatus enum
 const (
 	HandlerAvailable HandlerStatus = iota
 	HandlerNotAvailable
@@ -67,7 +68,9 @@ const (
 
 // RouteHandler is an external check handler for a route
 type RouteHandler interface {
+	// IsAvailable returns HandlerStatus represents the handler will be used/not used/stop next handler check
 	IsAvailable(context.Context, ClusterSnapshot) HandlerStatus
+	// Route returns handler's route
 	Route() Route
 }
 type RouterWrapper interface {


### PR DESCRIPTION
Optimize handler chain

1.  RouterHandler returns Status instead of bool, can stop directly (route not found) 
2. HandlerChain keeps the clustersnapshot, returns to proxy,  so the Handler's snapshot is same as proxy used 