### PR TITLE
fix: if querystring is empty should not append question mark at end of the url

### DIFF
--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -272,8 +272,7 @@ func (s *clientStream) AppendHeaders(context context.Context, headers types.Head
 	}
 
 	if URI != "" {
-
-		if queryString, ok := headersMap[protocol.MosnHeaderQueryStringKey]; ok {
+		if queryString, _ := headersMap[protocol.MosnHeaderQueryStringKey]; queryString != "" {
 			URI += "?" + queryString
 		}
 


### PR DESCRIPTION
### Issues associated with this PR

https://github.com/alipay/sofa-mosn/issues/120

![image](https://user-images.githubusercontent.com/1207064/48931481-8181bf00-ef31-11e8-8b9a-d8afe6ac8486.png)

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

Sign

### Solutions
if querystring is empty should not append it to url

### UT result
All passed

### Benchmark
N/A

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result

Done