### PR TITLE
fix 267, support direct response

### DIFF
--- a/pkg/api/v2/config.go
+++ b/pkg/api/v2/config.go
@@ -76,6 +76,7 @@ type RouterConfig struct {
 	Match           RouterMatch            `json:"match"`
 	Route           RouteAction            `json:"route"`
 	Redirect        RedirectAction         `json:"redirect"`
+	DirectResponse  *DirectResponseAction  `json:"direct_response"`
 	MetadataConfig  MetadataConfig         `json:"metadata"`
 	Decorator       Decorator              `json:"decorator"`
 	PerFilterConfig map[string]interface{} `json:"per_filter_config"`

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -373,6 +373,12 @@ type RedirectAction struct {
 	ResponseCode uint32 `json:"response_code"`
 }
 
+// DirectResponseAction represents the direct response parameters
+type DirectResponseAction struct {
+	StatusCode int    `json:"status"`
+	Body       string `json:"body"`
+}
+
 // WeightedCluster.
 // Multiple upstream clusters unsupport stream filter type:  healthcheckcan be specified for a given route.
 // The request is routed to one of the upstream

--- a/pkg/filter/stream/commonrule/commonrule.go
+++ b/pkg/filter/stream/commonrule/commonrule.go
@@ -19,14 +19,16 @@ package commonrule
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 
 	"github.com/alipay/sofa-mosn/pkg/filter"
 	"github.com/alipay/sofa-mosn/pkg/filter/stream/commonrule/model"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/types"
+	jsoniter "github.com/json-iterator/go"
 )
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func init() {
 	filter.RegisterStream("commonrule", CreateCommonRuleFilterFactory)

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -48,6 +48,10 @@ func (r *mockRoute) RouteRule() types.RouteRule {
 	return &mockRouteRule{}
 }
 
+func (r *mockRoute) DirectResponseRule() types.DirectResponseRule {
+	return nil
+}
+
 type mockRouteRule struct {
 	types.RouteRule
 }

--- a/pkg/router/directresponse.go
+++ b/pkg/router/directresponse.go
@@ -1,0 +1,14 @@
+package router
+
+type directResponseImpl struct {
+	status int
+	body   string
+}
+
+func (rule *directResponseImpl) StatusCode() int {
+	return rule.status
+}
+
+func (rule *directResponseImpl) Body() string {
+	return rule.body
+}

--- a/pkg/router/directresponse_test.go
+++ b/pkg/router/directresponse_test.go
@@ -1,0 +1,55 @@
+package router
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	jsoniter "github.com/json-iterator/go"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+func TestDirectResponse(t *testing.T) {
+	routeConfigStr := `{
+		"match": {
+			"prefix": "/"
+		},
+		"route": {
+			"cluster_name":"testcluster"
+		},
+		"direct_response": {
+			"status": 500,
+			"body": "test"
+		}
+	}`
+	routeCfg := &v2.Router{}
+	if err := json.Unmarshal([]byte(routeConfigStr), routeCfg); err != nil {
+		t.Fatal("unmarshal config to router failed, ", err)
+	}
+	rule, _ := NewRouteRuleImplBase(nil, routeCfg)
+	if rule.DirectResponseRule() == nil {
+		t.Fatal("rule have no direct response rule")
+	}
+	dr := rule.DirectResponseRule()
+	if dr.StatusCode() != 500 || dr.Body() != "test" {
+		t.Error("direct response rule is not exepcted")
+	}
+	// Test No Direct response by default
+	noDirectCfgStr := `{
+		"match": {
+			"prefix": "/"
+		},
+		"route": {
+			 "cluster_name":"testcluster"
+		}
+	}`
+	noDirectCfg := &v2.Router{}
+	if err := json.Unmarshal([]byte(noDirectCfgStr), noDirectCfg); err != nil {
+		t.Fatal("unmarshal config to router failed, ", err)
+	}
+	noDirectRule, _ := NewRouteRuleImplBase(nil, noDirectCfg)
+	if !reflect.ValueOf(noDirectRule.DirectResponseRule()).IsNil() {
+		t.Error("expected a nil resposne rule, but not", noDirectRule.DirectResponseRule())
+	}
+}

--- a/pkg/router/routersmanager_test.go
+++ b/pkg/router/routersmanager_test.go
@@ -24,7 +24,6 @@
 package router
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"

--- a/pkg/router/routeruleimpl.go
+++ b/pkg/router/routeruleimpl.go
@@ -69,6 +69,13 @@ func NewRouteRuleImplBase(vHost *VirtualHostImpl, route *v2.Router) (*RouteRuleI
 		routeRuleImplBase.metaData = getClusterMosnLBMetaDataMap(subsetLBMetaData)
 	}
 
+	if route.DirectResponse != nil {
+		routeRuleImplBase.directResponseRule = &directResponseImpl{
+			status: route.DirectResponse.StatusCode,
+			body:   route.DirectResponse.Body,
+		}
+	}
+
 	return &routeRuleImplBase, nil
 }
 
@@ -88,9 +95,6 @@ type RouteRuleImplBase struct {
 	clusterNotFoundResponseCode httpmosn.Code
 	timeout                     time.Duration
 	runtime                     v2.RuntimeUInt32
-	hostRedirect                string
-	pathRedirect                string
-	httpsRedirect               bool
 	retryPolicy                 *retryPolicyImpl
 	rateLimitPolicy             *rateLimitPolicyImpl
 
@@ -113,14 +117,13 @@ type RouteRuleImplBase struct {
 
 	opaqueConfig multimap.MultiMap
 
-	directResponseCode httpmosn.Code
-	directResponseBody string
-	policy             *routerPolicy
-	virtualClusters    *VirtualClusterEntry
-	randInstance       *rand.Rand
-	randMutex          sync.Mutex
+	policy          *routerPolicy
+	virtualClusters *VirtualClusterEntry
+	randInstance    *rand.Rand
+	randMutex       sync.Mutex
 
-	perFilterConfig map[string]interface{}
+	perFilterConfig    map[string]interface{}
+	directResponseRule *directResponseImpl
 }
 
 // types.RouterInfo
@@ -133,6 +136,10 @@ func (rri *RouteRuleImplBase) GetRouterName() string {
 func (rri *RouteRuleImplBase) RedirectRule() types.RedirectRule {
 
 	return nil
+}
+
+func (rri *RouteRuleImplBase) DirectResponseRule() types.DirectResponseRule {
+	return rri.directResponseRule
 }
 
 func (rri *RouteRuleImplBase) RouteRule() types.RouteRule {

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -84,6 +84,9 @@ type Route interface {
 
 	// RouteRule returns the route rule
 	RouteRule() RouteRule
+
+	// DirectResponseRule returns direct response rile
+	DirectResponseRule() DirectResponseRule
 }
 
 // RouteRule defines parameters for a route
@@ -281,6 +284,15 @@ type RedirectRule interface {
 	ResponseCode() interface{}
 
 	ResponseBody() string
+}
+
+// DirectResponseRule contains direct response info
+type DirectResponseRule interface {
+
+	// StatusCode returns the repsonse status code
+	StatusCode() int
+	// Body returns the response body string
+	Body() string
 }
 
 type MetadataMatchCriterion interface {


### PR DESCRIPTION
支持 Direct Response 功能 （HTTP）

+ Route新增DirectResponse相关配置以及接口
   + 可配置DirectResponse的StatusCode和Body
+ Proxy获取到路由以后，首先判断是否支持DirectResponse
   + 通过配置进行判断，如果Route的DirectResponse配置为空，则说明不支持DirectResponse
+ 如果支持DirectResponse，则直接响应
   + 对于HTTP/HTTP2 能够完全支持
   + 对于RPC，还存在一些问题：Status可能会被转换； 如果配置了Body， Header中关于Content相关的内容会不准确，因此暂时不支持RPC配置Body
