### PR TITLE
fix admin api can restart and default close

### DIFF
--- a/pkg/admin/stoppbale.go
+++ b/pkg/admin/stoppbale.go
@@ -15,19 +15,23 @@
  * limitations under the License.
  */
 
-package server
+package admin
 
 import (
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
-// stoppable implementation is moved to admin
-// keeps wraaper of admin to compatible
+var stoppables []types.Stoppable
+
 func AddStoppable(s types.Stoppable) {
-	admin.AddStoppable(s)
+	stoppables = append(stoppables, s)
 }
 
-func stopStoppable() {
-	admin.StopStoppable()
+func StopStoppable() {
+	for _, s := range stoppables {
+		if err := s.Close(); err != nil {
+			log.DefaultLogger.Infof("close stoppable error: %v", err)
+		}
+	}
 }

--- a/pkg/admin/types.go
+++ b/pkg/admin/types.go
@@ -4,6 +4,18 @@ import (
 	. "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 )
 
+/*
+{
+   "admin":{
+	"address":{
+	     "socket_address":{
+		     "address": "0.0.0.0",
+		     "port_value": 8888
+	     }
+	}
+   }
+}
+*/
 type Config interface {
 	GetAdmin() *Admin
 }

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -182,7 +182,6 @@ func (m *Mosn) Close() {
 // step1. NewMosn
 // step2. Start Mosn
 func Start(c *config.MOSNConfig, serviceCluster string, serviceNode string) {
-	initializeTracing(c.Tracing)
 	log.StartLogger.Infof("start by config : %+v", c)
 
 	wg := sync.WaitGroup{}

--- a/pkg/network/connection_test.go
+++ b/pkg/network/connection_test.go
@@ -90,7 +90,7 @@ func testAddBytesSendListener(n int, t *testing.T) {
 }
 
 func TestAddConnectionEventListener(t *testing.T) {
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 3; i++ {
 		name := fmt.Sprintf("AddConnectionEventListener(%d)", i)
 		t.Run(name, func(t *testing.T) {
 			testAddConnectionEventListener(i, t)
@@ -99,7 +99,7 @@ func TestAddConnectionEventListener(t *testing.T) {
 }
 
 func TestAddBytesReadListener(t *testing.T) {
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 3; i++ {
 		name := fmt.Sprintf("AddBytesReadListener(%d)", i)
 		t.Run(name, func(t *testing.T) {
 			testAddBytesReadListener(i, t)
@@ -108,7 +108,7 @@ func TestAddBytesReadListener(t *testing.T) {
 }
 
 func TestAddBytesSendListener(t *testing.T) {
-	for i := 0; i < 1024; i++ {
+	for i := 0; i < 3; i++ {
 		name := fmt.Sprintf("AddBytesSendListener(%d)", i)
 		t.Run(name, func(t *testing.T) {
 			testAddBytesSendListener(i, t)


### PR DESCRIPTION
1. Admin 也需要能够在热升级时，在新进程中Listen
2. Server包会引用Admin包，为了解决循环依赖问题，将Stoppable的实现移动到Admin包，并且为Server包保留兼容性接口（封装Admin包）
3. Admin API需要配置以后才开启，而不是没有配置的情况下默认占用一个端口