### PR TITLE
adjust endStream logic so changes to the cmd.data may work

### DIFF
--- a/pkg/protocol/rpc/sofarpc/codec/boltv1.go
+++ b/pkg/protocol/rpc/sofarpc/codec/boltv1.go
@@ -33,6 +33,7 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc"
 	"github.com/alipay/sofa-mosn/pkg/protocol/serialize"
 	"github.com/alipay/sofa-mosn/pkg/types"
+	"github.com/alipay/sofa-mosn/pkg/buffer"
 )
 
 var (
@@ -242,7 +243,7 @@ func (c *boltCodec) Decode(ctx context.Context, data types.IoBuffer) (interface{
 				request.ContentLen = int(contentLen)
 				request.ClassName = class
 				request.HeaderMap = header
-				request.Content = content
+				request.Content = buffer.NewIoBufferBytes(content)
 				sofarpc.DeserializeBoltRequest(ctx, request)
 
 				cmd = request
@@ -300,7 +301,7 @@ func (c *boltCodec) Decode(ctx context.Context, data types.IoBuffer) (interface{
 				response.ContentLen = int(contentLen)
 				response.ClassName = class
 				response.HeaderMap = header
-				response.Content = content
+				response.Content = buffer.NewIoBufferBytes(content)
 
 				response.ResponseTimeMillis = time.Now().UnixNano() / int64(time.Millisecond)
 				sofarpc.DeserializeBoltResponse(ctx, response)

--- a/pkg/protocol/rpc/sofarpc/codec/boltv2.go
+++ b/pkg/protocol/rpc/sofarpc/codec/boltv2.go
@@ -29,6 +29,7 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc"
 	"github.com/alipay/sofa-mosn/pkg/protocol/serialize"
 	"github.com/alipay/sofa-mosn/pkg/types"
+	"github.com/alipay/sofa-mosn/pkg/buffer"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 )
 
 func init() {
-	sofarpc.RegisterProtocol(sofarpc.PROTOCOL_CODE_V2, BoltCodecV2, BoltCodecV2,nil)
+	sofarpc.RegisterProtocol(sofarpc.PROTOCOL_CODE_V2, BoltCodecV2, BoltCodecV2, nil)
 	sofarpc.RegisterResponseBuilder(sofarpc.PROTOCOL_CODE_V2, BoltCodecV2)
 	// the heartbeat processing is same with boltV1
 	sofarpc.RegisterHeartbeatBuilder(sofarpc.PROTOCOL_CODE_V2, BoltCodec)
@@ -248,7 +249,7 @@ func (c *boltCodecV2) Decode(ctx context.Context, data types.IoBuffer) (interfac
 						int(contentLen),
 						class,
 						header,
-						content,
+						buffer.NewIoBufferBytes(content),
 						"",
 						nil,
 					},
@@ -312,7 +313,7 @@ func (c *boltCodecV2) Decode(ctx context.Context, data types.IoBuffer) (interfac
 						int(contentLen),
 						class,
 						header,
-						content,
+						buffer.NewIoBufferBytes(content),
 						"",
 						nil,
 						time.Now().UnixNano() / int64(time.Millisecond),

--- a/pkg/protocol/rpc/sofarpc/types.go
+++ b/pkg/protocol/rpc/sofarpc/types.go
@@ -48,7 +48,6 @@ type HeartbeatBuilder interface {
 
 // HeartbeatBuilder provides interface to construct proper response command for sofarpc sub-protocols
 type ResponseBuilder interface {
-
 	// BuildResponse build response with given status code
 	BuildResponse(status int16) SofaRpcCmd
 }
@@ -199,7 +198,7 @@ type BoltRequest struct {
 	ContentLen int
 	ClassName  []byte
 	HeaderMap  []byte
-	Content    []byte
+	Content    types.IoBuffer
 
 	RequestClass  string // deserialize fields
 	RequestHeader map[string]string
@@ -218,7 +217,7 @@ func (b *BoltRequest) Header() map[string]string {
 	return b.RequestHeader
 }
 
-func (b *BoltRequest) Data() []byte {
+func (b *BoltRequest) Data() types.IoBuffer {
 	return b.Content
 }
 
@@ -230,7 +229,7 @@ func (b *BoltRequest) SetHeader(header map[string]string) {
 	b.RequestHeader = header
 }
 
-func (b *BoltRequest) SetData(data []byte) {
+func (b *BoltRequest) SetData(data types.IoBuffer) {
 	b.Content = data
 }
 
@@ -303,7 +302,7 @@ type BoltResponse struct {
 	ContentLen int
 	ClassName  []byte
 	HeaderMap  []byte
-	Content    []byte
+	Content    types.IoBuffer
 
 	ResponseClass  string // deserialize fields
 	ResponseHeader map[string]string
@@ -324,7 +323,7 @@ func (b *BoltResponse) Header() map[string]string {
 	return b.ResponseHeader
 }
 
-func (b *BoltResponse) Data() []byte {
+func (b *BoltResponse) Data() types.IoBuffer {
 	return b.Content
 }
 
@@ -336,7 +335,7 @@ func (b *BoltResponse) SetHeader(header map[string]string) {
 	b.ResponseHeader = header
 }
 
-func (b *BoltResponse) SetData(data []byte) {
+func (b *BoltResponse) SetData(data types.IoBuffer) {
 	b.Content = data
 }
 

--- a/pkg/protocol/rpc/types.go
+++ b/pkg/protocol/rpc/types.go
@@ -47,11 +47,11 @@ type RpcCmd interface {
 
 	Header() map[string]string
 
-	Data() []byte
+	Data() types.IoBuffer
 
 	SetHeader(header map[string]string)
 
-	SetData(data []byte)
+	SetData(data types.IoBuffer)
 }
 
 // ResponseStatus describe that the model has the [response status] information

--- a/pkg/protocol/rpc/xprotocol/factory.go
+++ b/pkg/protocol/rpc/xprotocol/factory.go
@@ -47,7 +47,7 @@ type Coder struct {
 func (coder *Coder) Encode(ctx context.Context, model interface{}) (types.IoBuffer, error) {
 	xRpcCmd, ok := model.(*XRpcCmd)
 	if ok {
-		return networkbuffer.NewIoBufferBytes(xRpcCmd.data), nil
+		return xRpcCmd.data, nil
 	}
 	err := errors.New("fail to convert to XRpcCmd")
 	return nil, err
@@ -93,7 +93,7 @@ func CreateSubProtocolCodec(context context.Context, prot SubProtocol) Multiplex
 type XRpcCmd struct {
 	ctx    context.Context
 	codec  Multiplexing
-	data   []byte
+	data   types.IoBuffer
 	header map[string]string
 }
 
@@ -106,7 +106,7 @@ func (xRpcCmd *XRpcCmd) ProtocolCode() byte {
 
 // RequestID no use util we change multiplexing interface
 func (xRpcCmd *XRpcCmd) RequestID() uint64 {
-	streamId := xRpcCmd.codec.GetStreamID(xRpcCmd.data)
+	streamId := xRpcCmd.codec.GetStreamID(xRpcCmd.data.Bytes())
 	requestId, err := strconv.ParseUint(streamId, 10, 64)
 	if err != nil {
 		log.DefaultLogger.Errorf("get request id fail,streamId = %v", streamId)
@@ -118,7 +118,7 @@ func (xRpcCmd *XRpcCmd) RequestID() uint64 {
 // SetRequestID no use util we change multiplexing interface
 func (xRpcCmd *XRpcCmd) SetRequestID(requestID uint64) {
 	streamId := strconv.FormatUint(requestID, 10)
-	xRpcCmd.data = xRpcCmd.codec.SetStreamID(xRpcCmd.data, streamId)
+	xRpcCmd.data = networkbuffer.NewIoBufferBytes(xRpcCmd.codec.SetStreamID(xRpcCmd.data.Bytes(), streamId))
 }
 
 // Header no use util we change multiplexing interface
@@ -127,7 +127,7 @@ func (xRpcCmd *XRpcCmd) Header() map[string]string {
 }
 
 // Data no use util we change multiplexing interface
-func (xRpcCmd *XRpcCmd) Data() []byte {
+func (xRpcCmd *XRpcCmd) Data() types.IoBuffer {
 	return xRpcCmd.data
 }
 
@@ -137,7 +137,7 @@ func (xRpcCmd *XRpcCmd) SetHeader(header map[string]string) {
 }
 
 // SetData no use util we change multiplexing interface
-func (xRpcCmd *XRpcCmd) SetData(data []byte) {
+func (xRpcCmd *XRpcCmd) SetData(data types.IoBuffer) {
 	xRpcCmd.data = data
 }
 

--- a/pkg/protocol/rpc/xprotocol/factory_test.go
+++ b/pkg/protocol/rpc/xprotocol/factory_test.go
@@ -122,7 +122,7 @@ func Test_XRpcCmd_0(t *testing.T) {
 	xRpcCmd := &XRpcCmd{
 		ctx:    nil,
 		codec:  CreateSubProtocolCodec(nil, SubProtocol("ut-example")),
-		data:   []byte{14, 1, 0, 8, 0, 0, 3, 0},
+		data:   networkbuffer.NewIoBufferBytes([]byte{14, 1, 0, 8, 0, 0, 3, 0}),
 		header: header,
 	}
 
@@ -140,7 +140,7 @@ func Test_XRpcCmd_0(t *testing.T) {
 		t.Errorf("data should be nil, set data fail")
 	}
 
-	xRpcCmd.SetData([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	xRpcCmd.SetData(networkbuffer.NewIoBufferBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0}))
 	xRpcCmd.SetRequestID(1)
 	if xRpcCmd.RequestID() != 1 {
 		t.Errorf("set request id fail,should be 1")
@@ -152,7 +152,7 @@ func Test_XRpcCmd_1(t *testing.T) {
 	xRpcCmd := &XRpcCmd{
 		ctx:    nil,
 		codec:  CreateSubProtocolCodec(nil, SubProtocol("ut-example")),
-		data:   []byte{14, 1, 0, 8, 0, 0, 3, 0},
+		data:   networkbuffer.NewIoBufferBytes([]byte{14, 1, 0, 8, 0, 0, 3, 0}),
 		header: header,
 	}
 	// Xprotocol plugin test
@@ -187,7 +187,7 @@ func Test_XRpcCmd_2(t *testing.T) {
 	xRpcCmd := &XRpcCmd{
 		ctx:    nil,
 		codec:  CreateSubProtocolCodec(nil, SubProtocol("ut-example")),
-		data:   []byte{14, 1, 0, 8, 0, 0, 3, 0},
+		data:   networkbuffer.NewIoBufferBytes([]byte{14, 1, 0, 8, 0, 0, 3, 0}),
 		header: header,
 	}
 	// HeaderMap test


### PR DESCRIPTION
# 说明
1. 调整`RpcCmd`接口声明，将data相关参数类型调整为`types.IoBuffer`，避免SetData+Data调用导致的IoBuffer无法复用
2. 调整sofa stream的endStream实现，写数据时，使用cmd.Data而非stream.encodedData，使得在stream处理过程中可能存在的对data的修改可以生效(例如TR协议的replace requestID，需要修改data)。