### PR TITLE
run stream filter before route check

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -279,8 +279,9 @@ func (s *downStream) doReceiveHeaders(filter *activeStreamReceiverFilter, header
 	routers := s.proxy.routersWrapper.GetRouters()
 	// do handler chain
 	handlerChain := router.CallMakeHandlerChain(headers, routers, s.proxy.clusterManager)
+	// handlerChain should never be nil
 	if handlerChain == nil {
-		log.DefaultLogger.Warnf("no route to make handler chain, headers = %v", headers)
+		log.DefaultLogger.Errorf("no route to make handler chain, headers = %v", headers)
 		s.requestInfo.SetResponseFlag(types.NoRouteFound)
 		s.sendHijackReply(types.RouterUnavailableCode, headers)
 		return

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -289,9 +289,12 @@ func (s *downStream) doReceiveHeaders(filter *activeStreamReceiverFilter, header
 	clusterSnapshot, route := handlerChain.DoNextHandler()
 	s.route = route
 	// run stream filters after route is choosed
+	// the route maybe nil, but the stream filter should also be run
+	// stream filter maybe send a hijack reply ignore the route
 	if s.runReceiveHeadersFilters(filter, headers, endStream) {
 		return
 	}
+	// after stream filters run, check the route
 	if route == nil {
 		log.DefaultLogger.Warnf("no route to init upstream,headers = %v", headers)
 		s.requestInfo.SetResponseFlag(types.NoRouteFound)

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -79,12 +79,11 @@ func (h *simpleHandler) Route() types.Route {
 }
 
 func DefaultMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {
+	var handlers []types.RouteHandler
 	if r := routers.Route(headers, 1); r != nil {
-		return NewRouteHandlerChain(context.Background(), clusterManager, []types.RouteHandler{
-			&simpleHandler{route: r},
-		})
+		handlers = append(handlers, &simpleHandler{route: r})
 	}
-	return nil
+	return NewRouteHandlerChain(context.Background(), clusterManager, handlers)
 }
 
 func CallMakeHandlerChain(headers types.HeaderMap, routers types.Routers, clusterManager types.ClusterManager) *RouteHandlerChain {

--- a/pkg/router/handlerchain_test.go
+++ b/pkg/router/handlerchain_test.go
@@ -100,8 +100,12 @@ func TestDefaultMakeHandlerChain(t *testing.T) {
 	}
 	// header not match, no handlers
 	headerNotMatch := protocol.CommonHeader(map[string]string{})
-	if hc := CallMakeHandlerChain(headerNotMatch, routers, clusterManager); hc != nil {
+	if hc := CallMakeHandlerChain(headerNotMatch, routers, clusterManager); hc == nil {
 		t.Fatal("make handler chain unexpected")
+	} else {
+		if _, r := hc.DoNextHandler(); r != nil {
+			t.Fatal("do next handler failed")
+		}
 	}
 
 }

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -201,7 +201,7 @@ func (p *routerPolicy) LoadBalancerPolicy() types.LoadBalancerPolicy {
 // RouterRuleFactory creates a RouteBase
 type RouterRuleFactory func(base *RouteRuleImplBase, header []v2.HeaderMatcher) RouteBase
 
-// MakeHandlerChain creates a RouteHandlerChain
+// MakeHandlerChain creates a RouteHandlerChain, should not returns a nil handler chain, or the stream filters will be ignored
 type MakeHandlerChain func(types.HeaderMap, types.Routers, types.ClusterManager) *RouteHandlerChain
 
 // The reigister order, is a wrapper of registered factory


### PR DESCRIPTION
有时候，希望请求即便没有匹配上router，也要执行stream filter； 但是有的stream filter是需要router信息的，因此将stream filter的执行逻辑修改到 route选择之后，但是route是否选择到的校验之前