### PR TITLE
Fix Logtime and add testcase

### DIFF
--- a/pkg/log/accesslog.go
+++ b/pkg/log/accesslog.go
@@ -251,7 +251,7 @@ func formatToFormatter(format string) []types.AccessLogFormatter {
 // StartTimeGetter
 // get request's arriving time
 func StartTimeGetter(info types.RequestInfo) string {
-	return logTime(info.StartTime(), true)
+	return info.StartTime().Format("2006/01/02 15:04:05.999")
 }
 
 // ReceivedDurationGetter

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -247,7 +247,7 @@ func (l *logger) Println(args ...interface{}) {
 }
 
 func (l *logger) Printf(format string, args ...interface{}) {
-	s := fmt.Sprintf(logTime(time.Now(), false)+" "+format, args...)
+	s := fmt.Sprintf(logTime()+" "+format, args...)
 	buf := buffer.GetIoBuffer(len(s))
 	buf.WriteString(s)
 	if len(s) == 0 || s[len(s)-1] != '\n' {
@@ -287,7 +287,7 @@ func (l *logger) Tracef(format string, args ...interface{}) {
 }
 
 func (l *logger) Fatalf(format string, args ...interface{}) {
-	s := fmt.Sprintf(logTime(time.Now(), false)+" "+FatalPre+format, args...)
+	s := fmt.Sprintf(logTime()+" "+FatalPre+format, args...)
 	buf := buffer.GetIoBuffer(len(s))
 	buf.WriteString(s)
 	buf.WriteTo(l.writer)
@@ -297,7 +297,7 @@ func (l *logger) Fatalf(format string, args ...interface{}) {
 func (l *logger) Fatal(args ...interface{}) {
 	s := fmt.Sprint(args...)
 	buf := buffer.GetIoBuffer(len(s))
-	buf.WriteString(logTime(time.Now(), false) + " " + FatalPre)
+	buf.WriteString(logTime() + " " + FatalPre)
 	buf.WriteString(s)
 	if len(s) == 0 || s[len(s)-1] != '\n' {
 		buf.WriteString("\n")
@@ -309,7 +309,7 @@ func (l *logger) Fatal(args ...interface{}) {
 func (l *logger) Fatalln(args ...interface{}) {
 	s := fmt.Sprintln(args...)
 	buf := buffer.GetIoBuffer(len(s))
-	buf.WriteString(logTime(time.Now(), false) + " " + FatalPre)
+	buf.WriteString(logTime() + " " + FatalPre)
 	buf.WriteString(s)
 	if len(s) == 0 || s[len(s)-1] != '\n' {
 		buf.WriteString("\n")
@@ -398,9 +398,10 @@ func CloseAll() error {
 	return nil
 }
 
-func logTime(t time.Time, ms bool) string {
+func logTime() string {
 	var s string
-	now := time.Now().Unix()
+	t := time.Now()
+	now := t.Unix()
 	value := lastTime.Load()
 	if value != nil {
 		last := value.(*timeCache)
@@ -409,35 +410,10 @@ func logTime(t time.Time, ms bool) string {
 		}
 	}
 	if s == "" {
-		b := make([]byte, 0, 36)
-		buf := &b
-		year, month, day := t.Date()
-		itoa(buf, year, 4)
-		*buf = append(*buf, '/')
-		itoa(buf, int(month), 2)
-		*buf = append(*buf, '/')
-		itoa(buf, day, 2)
-		*buf = append(*buf, ' ')
-		hour, min, sec := t.Clock()
-		itoa(buf, hour, 2)
-		*buf = append(*buf, ':')
-		itoa(buf, min, 2)
-		*buf = append(*buf, ':')
-		itoa(buf, sec, 2)
-		s = string(*buf)
-
+		s = t.Format("2006/01/02 15:04:05")
 		lastTime.Store(&timeCache{now, s})
 	}
-
-	if ms {
-		b := make([]byte, 0, 4)
-		buf := &b
-		*buf = append(*buf, '.')
-		itoa(buf, t.Nanosecond()/1e6, 3)
-		return s + string(*buf)
-	} else {
-		return s
-	}
+	return s
 }
 
 // Cheap integer to fixed-width decimal ASCII. Give a negative width to avoid zero-padding.

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"testing"
 	"time"
+	"os"
 )
 
 func TestLogPrintDiscard(t *testing.T) {
@@ -49,6 +50,29 @@ func TestLogPrintDiscard(t *testing.T) {
 	}
 }
 
+func TestLogPrintnull(t *testing.T) {
+	logName := "/tmp/mosn_bench/printnull.log"
+	os.Remove(logName)
+	l, _ := NewLogger(logName, DEBUG)
+	buf := buffer.GetIoBuffer(0)
+	buf.WriteString("testlog")
+	l.Print(buf, false)
+	buf = buffer.GetIoBuffer(0)
+	buf.WriteString("")
+	l.Print(buf, false)
+	l.Close()
+	f, _ := os.Open(logName)
+	b := make([]byte, 1024)
+	n, _ := f.Read(b)
+	f.Close()
+	if n != len("testlog") {
+		t.Errorf("Printnull error")
+	}
+	if string(b[:n]) != "testlog" {
+		t.Errorf("Printnull error")
+	}
+}
+
 func BenchmarkLog(b *testing.B) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	//InitDefaultLogger("", INFO)
@@ -69,4 +93,18 @@ func BenchmarkLogParallel(b *testing.B) {
 			l.Debugf("BenchmarkLog BenchmarkLog BenchmarkLog BenchmarkLog BenchmarkLog %v", l)
 		}
 	})
+}
+
+func BenchmarkLogTimeFormat(b *testing.B) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	for n := 0; n < b.N; n++ {
+		time.Now().Format("2006/01/02 15:04:05")
+	}
+}
+
+func BenchmarkLogTime(b *testing.B) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	for n := 0; n < b.N; n++ {
+		logTime()
+	}
 }

--- a/pkg/log/roller.go
+++ b/pkg/log/roller.go
@@ -124,9 +124,9 @@ func DefaultRoller() *Roller {
 
 const (
 	// defaultRotateSize is 100 MB.
-	defaultRotateSize = 2000
-	// defaultRotateAge is 14 days.
-	defaultRotateAge = 1
+	defaultRotateSize = 1000
+	// defaultRotateAge is 7 days.
+	defaultRotateAge = 7
 	// defaultRotateKeep is 10 files.
 	defaultRotateKeep = 10
 


### PR DESCRIPTION
### Issues associated with this PR


### Sign the CLA

### Solutions
修改logTime()实现， 使用场景为错误日志的时间记录。
access的时间记录不适用该函数，已fix

### UT result


### Benchmark
BenchmarkLogTimeFormat
1000000	      1049 ns/op

BenchmarkLogTime
2000000	       637 ns/op




### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
