### PR TITLE
fix : CDS deep equals configure always fail

### DIFF
--- a/pkg/upstream/cluster/clustermanager.go
+++ b/pkg/upstream/cluster/clustermanager.go
@@ -214,7 +214,8 @@ func (cm *clusterManager) ClusterExist(clusterName string) bool {
 }
 
 func (cm *clusterManager) updateCluster(clusterConf v2.Cluster, pcluster *primaryCluster, addedViaAPI bool) bool {
-	if reflect.DeepEqual(clusterConf, pcluster.configUsed) {
+	// diff cluster
+	if reflect.DeepEqual(clusterConf, *(pcluster.configUsed)) {
 		log.DefaultLogger.Debugf("update cluster but get duplicate configure")
 		return true
 	}


### PR DESCRIPTION
### Issues associated with this PR
For #449
reflect.DeepEqual with v2.Cluster and *v2.Cluster will always return fail 
fix this type mistake
