### PR TITLE
support append router rule and host, support router dump

### DIFF
--- a/pkg/config/configmanager.go
+++ b/pkg/config/configmanager.go
@@ -55,9 +55,14 @@ func ResetServiceRegistryInfo(appInfo v2.ApplicationInfo, subServiceList []strin
 	removeClusterConfig(subServiceList)
 }
 
-// AddClusterConfig
+// AddOrUpdateClusterConfig
 // called when add cluster config info received
-func AddClusterConfig(clusters []v2.Cluster) {
+func AddOrUpdateClusterConfig(clusters []v2.Cluster) {
+	addOrUpdateClusterConfig(clusters)
+	go dump(true)
+}
+
+func addOrUpdateClusterConfig(clusters []v2.Cluster) {
 	for _, clusterConfig := range clusters {
 		exist := false
 
@@ -74,11 +79,7 @@ func AddClusterConfig(clusters []v2.Cluster) {
 		if !exist {
 			config.ClusterManager.Clusters = append(config.ClusterManager.Clusters, clusterConfig)
 		}
-
-		// update routes
-		//AddRouterConfig(cluster.Name)
 	}
-	go dump(true)
 }
 
 func removeClusterConfig(clusterNames []string) {
@@ -141,6 +142,14 @@ func DelPubInfo(serviceName string) {
 	}
 
 	go dump(dirty)
+}
+
+// AddClusterWithRouter is a wrapper of AddOrUpdateCluster and AddRoutersConfig
+// use this function to only dump config once
+func AddClusterWithRouter(listenername string, virtualhost string, router v2.Router, clusters []v2.Cluster) {
+	addOrUpdateClusterConfig(clusters)
+	addRoutersConfig(listenername, virtualhost, router)
+	go dump(true)
 }
 
 // AddRoutersConfig dumps addRoutersConfig result

--- a/pkg/config/configmanager.go
+++ b/pkg/config/configmanager.go
@@ -22,6 +22,8 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/log"
 )
 
+// TODO: The functions in this file is for service discovery, but the function implmentation is not general, should fix it
+
 // dumper provides basic operation with mosn elements, like 'cluster', to write back the config file with dynamic changes
 // biz logic operation, like 'clear all subscribe info', should be written in the bridge code, not in config module.
 //
@@ -141,33 +143,69 @@ func DelPubInfo(serviceName string) {
 	go dump(dirty)
 }
 
-// AddRouterConfig
-// Add router from config when new cluster created
-func AddRouterConfig(clusterName string) {
-	routerName := clusterName[0 : len(clusterName)-8]
+// AddRoutersConfig dumps addRoutersConfig result
+func AddRoutersConfig(listenername string, virtualhost string, router v2.Router) {
+	if addRoutersConfig(listenername, virtualhost, router) {
+		go dump(true)
+	}
+}
 
-	for _, l := range config.Servers[0].Listeners {
-		if routers, ok := l.FilterChains[0].Filters[0].Config["routes"].([]interface{}); ok {
-			// remove repetition
-			for _, route := range routers {
-				if r, ok := route.(map[string]interface{}); ok {
-					if n, ok := r["name"].(string); ok {
-						if n == routerName {
-							return
-						}
-					}
+// addRoutersConfig effects listener config.
+// routers in listener.connection_manager.virtual_hosts, if a virtual host name is empty, use default virtual host
+func addRoutersConfig(listenername string, virtualhost string, router v2.Router) bool {
+	dirty := false
+	// support only one server
+	listeners := config.Servers[0].Listeners
+	for _, ln := range listeners {
+		if ln.Name != listenername {
+			continue
+		}
+		// support only one filter chain
+		nfs := ln.FilterChains[0].Filters
+	FindRouter:
+		for filterIndex, nf := range nfs {
+			if nf.Type != v2.CONNECTION_MANAGER {
+				continue FindRouter
+			}
+			routerConfiguration := &v2.RouterConfiguration{}
+			if data, err := json.Marshal(nf.Config); err == nil {
+				if err := json.Unmarshal(data, routerConfiguration); err != nil {
+					log.DefaultLogger.Errorf("invalid router config, update config failed")
+					break FindRouter
 				}
 			}
-
-			// append router
-			var s = make(map[string]interface{}, 4)
-			s["name"] = routerName
-			s["service"] = routerName
-			s["cluster"] = clusterName
-			routers = append(routers, s)
-			l.FilterChains[0].Filters[0].Config["routes"] = routers
-		} else {
-			log.DefaultLogger.Println(l.FilterChains[0].Filters[0].Config["routes"])
+			var vhost *v2.VirtualHost
+			vhs := routerConfiguration.VirtualHosts
+		FindVirtualHost:
+			for _, vh := range vhs {
+				if virtualhost == "" {
+					if len(vh.Domains) > 0 && vh.Domains[0] == "*" {
+						vhost = vh
+						break FindVirtualHost
+					}
+				} else if vh.Name == virtualhost {
+					vhost = vh
+					break FindVirtualHost
+				}
+			}
+			if vhost != nil {
+				vhost.Routers = append(vhost.Routers, router)
+				dirty = true
+			}
+			if dirty {
+				filterConfig := make(map[string]interface{})
+				if data, err := json.Marshal(routerConfiguration); err == nil {
+					if err := json.Unmarshal(data, &filterConfig); err != nil {
+						log.DefaultLogger.Errorf("rewrite filter config failed")
+						return false
+					}
+				}
+				nfs[filterIndex] = v2.Filter{
+					Type:   v2.CONNECTION_MANAGER,
+					Config: filterConfig,
+				}
+			}
 		}
 	}
+	return dirty
 }

--- a/pkg/config/configmanager_test.go
+++ b/pkg/config/configmanager_test.go
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
+)
+
+func mockInitConfig(t *testing.T, cfg []byte) {
+	// config is a global var
+	if err := json.Unmarshal(cfg, &config); err != nil {
+		t.Fatal("init config failed", err)
+	}
+}
+
+func TestAddRoutersConfig(t *testing.T) {
+	// only keep useful test part
+	cfg := []byte(`{
+		"servers": [
+			{
+				"listeners": [
+					{
+						"name": "egress",
+						"filter_chains": [
+							{
+								"filters": [
+									{
+										"type":"connection_manager",
+										"config":{
+											"router_config_name":"egress_router",
+											"virtual_hosts":[
+												{
+													"name": "egress",
+													"domains":["*"],
+													"routers": [
+														{
+															"match": {"prefix":"/"},
+															"route":{"cluster_name":"test1"}
+														}
+													]
+												}
+											]
+										}		
+									}	
+								]
+							}
+						]
+					},
+					{
+						"name": "ingress",
+						"filter_chains": [
+							{
+								"filters": [
+									{
+										"type":"connection_manager",
+									 	"config":{
+											"router_config_name":"egress_router",
+										 	"virtual_hosts":[
+										 		{
+													"name": "ingress",
+													"domains":["*"],
+													"routers": [
+														{
+															"match": {"prefix":"/"},
+															"route":{"cluster_name":"test1"}
+														}
+													]
+												}
+										 	]
+									 	}
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		]
+	}`)
+	mockInitConfig(t, cfg)
+	router := v2.Router{
+		RouterConfig: v2.RouterConfig{
+			Match: v2.RouterMatch{
+				Headers: []v2.HeaderMatcher{
+					{
+						Name:  "service",
+						Value: "test_new",
+					},
+				},
+			},
+			Route: v2.RouteAction{
+				RouterActionConfig: v2.RouterActionConfig{
+					ClusterName: "test_new",
+				},
+			},
+		},
+	}
+	// add a default virtual host
+	if ok := addRoutersConfig("egress", "", router); !ok {
+		t.Error("add egress router failed")
+	}
+	// add a specify virtual host
+	if ok := addRoutersConfig("ingress", "ingress", router); !ok {
+		t.Error("add ingress router failed")
+	}
+	// add a listener not exists
+	if ok := addRoutersConfig("not_exists", "", router); ok {
+		t.Error("add a not exists listener config")
+	}
+	// verify
+	listeners := config.Servers[0].Listeners
+	for _, ln := range listeners {
+		filter := ln.FilterChains[0].Filters[0] // only one connection_manager
+		if filter.Type != v2.CONNECTION_MANAGER {
+			t.Errorf("listener %s filter is not expected, get %s", ln.Name, filter.Type)
+			continue
+		}
+		routerConfiguration := &v2.RouterConfiguration{}
+		if data, err := json.Marshal(filter.Config); err == nil {
+			if err := json.Unmarshal(data, routerConfiguration); err != nil {
+				t.Errorf("invalid router config got, listener %s", ln.Name)
+				continue
+			}
+		}
+		if len(routerConfiguration.VirtualHosts[0].Routers) != 2 {
+			t.Errorf("not enough router rule found in listener %s", ln.Name)
+		}
+		findOriginal := false
+		findNew := false
+		for _, r := range routerConfiguration.VirtualHosts[0].Routers {
+			switch r.Route.ClusterName {
+			case "test_new":
+				findNew = true
+			case "test1":
+				findOriginal = true
+			}
+		}
+		if !findOriginal || !findNew {
+			t.Errorf("listener %s, original router: %v, new router: %v", ln.Name, findOriginal, findNew)
+		}
+	}
+}

--- a/pkg/protocol/types.go
+++ b/pkg/protocol/types.go
@@ -54,6 +54,8 @@ const (
 	IstioHeaderHostKey = "authority"
 )
 
+// TODO: move CommonHeader to common, not only in protocol
+
 // CommonHeader wrapper for map[string]string
 type CommonHeader map[string]string
 

--- a/pkg/router/handlerchain.go
+++ b/pkg/router/handlerchain.go
@@ -46,6 +46,9 @@ func (hc *RouteHandlerChain) DoNextHandler() (types.ClusterSnapshot, types.Route
 	if handler == nil {
 		return nil, nil
 	}
+	if handler.Route() == nil {
+		return hc.DoNextHandler()
+	}
 	clusterName := handler.Route().RouteRule().ClusterName()
 	snapshot := hc.clusterManager.GetClusterSnapshot(context.Background(), clusterName)
 	status := handler.IsAvailable(hc.ctx, snapshot)

--- a/pkg/router/routersmanager_test.go
+++ b/pkg/router/routersmanager_test.go
@@ -348,10 +348,10 @@ func Test_routersManager_AppendRoutersInVirtualHost(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		router := routers[i]
 		wg.Add(1)
-		go func() {
+		go func(router v2.Router) {
 			routerManager.AppendRoutersInVirtualHost(routerConfigName, "", router)
 			wg.Done()
-		}()
+		}(router)
 	}
 	wg.Wait()
 	// verify, use header match

--- a/pkg/router/routersmanager_test.go
+++ b/pkg/router/routersmanager_test.go
@@ -24,9 +24,12 @@
 package router
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	"github.com/alipay/sofa-mosn/pkg/protocol"
+	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
 var routerConfig = `{
@@ -206,14 +209,14 @@ func Test_routersManager_AddOrUpdateRouters(t *testing.T) {
 
 	routerConfigName := "test_router"
 
-	if _, ok := GetRoutersMangerInstance().routersMap.Load(routerConfigName); ok {
+	if _, ok := routersMangerInstance.routersMap.Load(routerConfigName); ok {
 		t.Errorf("test_router already exist")
 	}
 
 	if err := routerManager.AddOrUpdateRouters(router); err != nil {
 		t.Errorf(err.Error())
 	} else {
-		if value, ok := GetRoutersMangerInstance().routersMap.Load(routerConfigName); !ok {
+		if value, ok := routersMangerInstance.routersMap.Load(routerConfigName); !ok {
 			t.Errorf("AddOrUpdateRouters error, %s not found", routerConfigName)
 		} else {
 			if primaryRouters, ok := value.(*RoutersWrapper); ok {
@@ -279,5 +282,115 @@ func Test_routersManager_GetRouterWrapperByName(t *testing.T) {
 	// expect router has been updated for origin wrapper
 	if routers0_ != routers2 || routers1_ != routers2 {
 		t.Error("expect wrapper still the same but not ")
+	}
+}
+
+func Test_routersManager_AppendRoutersInVirtualHost(t *testing.T) {
+	routerManager := NewRouterManager()
+	bytes := []byte(routerConfig)
+	router := &v2.RouterConfiguration{}
+
+	if err := json.Unmarshal(bytes, router); err != nil {
+		t.Errorf(err.Error())
+	}
+
+	routerConfigName := "test_router"
+
+	if err := routerManager.AddOrUpdateRouters(router); err != nil {
+		t.Error("init router failed", err)
+	}
+
+	// add new routers with concurrency
+	routers := []v2.Router{
+		{
+			RouterConfig: v2.RouterConfig{
+				Match: v2.RouterMatch{
+					Path: "/test",
+				},
+				Route: v2.RouteAction{
+					RouterActionConfig: v2.RouterActionConfig{
+						ClusterName: "path",
+					},
+				},
+			},
+		},
+		{
+			RouterConfig: v2.RouterConfig{
+				Match: v2.RouterMatch{
+					Prefix: "/prefix-",
+				},
+				Route: v2.RouteAction{
+					RouterActionConfig: v2.RouterActionConfig{
+						ClusterName: "prefix",
+					},
+				},
+			},
+		},
+		{
+			RouterConfig: v2.RouterConfig{
+				Match: v2.RouterMatch{
+					Headers: []v2.HeaderMatcher{
+						{
+							Name:  types.SofaRouteMatchKey,
+							Value: ".*",
+						},
+					},
+				},
+				Route: v2.RouteAction{
+					RouterActionConfig: v2.RouterActionConfig{
+						ClusterName: "header",
+					},
+				},
+			},
+		},
+	}
+	wg := sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		router := routers[i]
+		wg.Add(1)
+		go func() {
+			routerManager.AppendRoutersInVirtualHost(routerConfigName, "", router)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	// verify, use header match
+	// all expected routers should match as expected
+	rw := GetRoutersMangerInstance().GetRouterWrapperByName(routerConfigName)
+	if rw == nil {
+		t.Error("no router test_router")
+	}
+	testCases := []struct {
+		headers     types.HeaderMap
+		ClusterName string
+	}{
+		{
+			headers: protocol.CommonHeader(map[string]string{
+				protocol.MosnHeaderPathKey: "/test",
+			}),
+			ClusterName: "path",
+		},
+		{
+			headers: protocol.CommonHeader(map[string]string{
+				protocol.MosnHeaderPathKey: "/prefix-1234",
+			}),
+			ClusterName: "prefix",
+		},
+		{
+			headers: protocol.CommonHeader(map[string]string{
+				types.SofaRouteMatchKey: "any",
+			}),
+			ClusterName: "header",
+		},
+	}
+	for i, tc := range testCases {
+		matched := rw.GetRouters().Route(tc.headers, 1)
+		if matched == nil {
+			t.Errorf("%d router rule not added success", i)
+			continue
+		}
+		if matched.RouteRule().ClusterName() != tc.ClusterName {
+			t.Errorf("%d router match result not expected, got cluster %s", i, matched.RouteRule().ClusterName())
+		}
 	}
 }

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -54,6 +54,9 @@ type RouterManager interface {
 	AddOrUpdateRouters(routerConfig *v2.RouterConfiguration) error
 
 	GetRouterWrapperByName(routerConfigName string) RouterWrapper
+
+	//a AppendRoutersInVirtualHost appends a router into virtualhsot
+	AppendRoutersInVirtualHost(routerConfigName string, virtualhost string, router v2.Router)
 }
 
 // HandlerStatus returns the Handler's available status

--- a/pkg/types/upstream.go
+++ b/pkg/types/upstream.go
@@ -48,6 +48,9 @@ type ClusterManager interface {
 	// temp interface todo: remove it
 	UpdateClusterHosts(cluster string, priority uint32, hosts []v2.Host) error
 
+	// AppendClusterHosts used to add cluster's hosts
+	AppendClusterHosts(clusterName string, priority uint32, hostConfigs []v2.Host) error
+
 	// Get or Create tcp conn pool for a cluster
 	TCPConnForCluster(balancerContext LoadBalancerContext, snapshot ClusterSnapshot) CreateConnectionData
 

--- a/pkg/upstream/cluster/clusteradapter.go
+++ b/pkg/upstream/cluster/clusteradapter.go
@@ -74,7 +74,7 @@ func (ca *MngAdapter) TriggerClusterDel(clusterName string) error {
 	return ca.clusterMng.RemovePrimaryCluster(clusterName)
 }
 
-// TriggerClusterHostUpdate used to Added or Update Cluster's hosts, return err if cluster not exist
+// TriggerClusterHostUpdate used to Update Cluster's hosts, return err if cluster not exist
 func (ca *MngAdapter) TriggerClusterHostUpdate(clusterName string, hosts []v2.Host) error {
 	if ca.clusterMng == nil {
 		return fmt.Errorf("TriggerClusterAddOrUpdate Error: cluster manager is nil")
@@ -85,7 +85,18 @@ func (ca *MngAdapter) TriggerClusterHostUpdate(clusterName string, hosts []v2.Ho
 
 // TriggerHostDel used to delete
 func (ca *MngAdapter) TriggerHostDel(clusterName string, hostAddress string) error {
+	if ca.clusterMng == nil {
+		return fmt.Errorf("TriggerHostDel Error: cluster manager is nil")
+	}
 	return ca.clusterMng.RemoveClusterHost(clusterName, hostAddress)
+}
+
+// TriggerHostAppend used to add cluster's host, return err if cluster not exist
+func (ca *MngAdapter) TriggerHostAppend(clusterName string, hostAppend []v2.Host) error {
+	if ca.clusterMng == nil {
+		return fmt.Errorf("TriggerHostAppend Error: cluster manager is nil")
+	}
+	return ca.clusterMng.AppendClusterHosts(clusterName, 0, hostAppend)
 }
 
 // GetCluster used to get cluster by name

--- a/pkg/upstream/cluster/clusteradapter_test.go
+++ b/pkg/upstream/cluster/clusteradapter_test.go
@@ -534,6 +534,24 @@ func TestMngAdapter_TriggerClusterHostUpdate(t *testing.T) {
 	}
 }
 
+func TestMngAdapter_TriggerHostAppend(t *testing.T) {
+	mockClusterMnger := MockClusterManager().(*clusterManager)
+	defer mockClusterMnger.Destory()
+	adapter := &MngAdapter{mockClusterMnger}
+	if err := adapter.TriggerHostAppend("o1", []v2.Host{host3, host4}); err != nil {
+		t.Error("append host failed")
+	}
+	if err := adapter.TriggerHostAppend("notexists", []v2.Host{}); err == nil {
+		t.Error("append host into cluster not exists")
+	}
+	// verify
+	snapshot := adapter.GetClusterSnapshot(context.Background(), "o1")
+	defer adapter.PutClusterSnapshot(snapshot)
+	if len(snapshot.PrioritySet().GetHostsInfo(0)) != 4 {
+		t.Error("add host success, but cannot get all of them")
+	}
+}
+
 func TestMngAdapter_TriggerHostDel(t *testing.T) {
 	mockClusterMnger := MockClusterManager().(*clusterManager)
 	defer mockClusterMnger.Destory()

--- a/pkg/upstream/cluster/clustermanager_test.go
+++ b/pkg/upstream/cluster/clustermanager_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 func TestPrimaryCluster(t *testing.T) {
-	pc := NewPrimaryCluster(&cluster{}, &v2.Cluster{}, true)
-	if err := pc.UpdateCluster(&cluster{}, &v2.Cluster{}, true); err != nil {
+	info := &clusterInfo{}
+	pc := NewPrimaryCluster(&cluster{info: info}, &v2.Cluster{}, true)
+	if err := pc.UpdateCluster(&cluster{info: info}, &v2.Cluster{}, true); err != nil {
 		t.Error("update cluster failed")
 	}
 	hostsconfig := []v2.Host{host1, host2, host3, host4}
 	var hosts []types.Host
-	info := &clusterInfo{}
 	for _, h := range hostsconfig {
 		hosts = append(hosts, NewHost(h, info))
 	}


### PR DESCRIPTION
基于需求的一些改造

1. 需要动态追加router的match规则，并且追加的router需要持久化
   + routers manager 增加追加规则
   + routers 动态更新以后，admin api需要感知
   + config 支持追加routers以后的dump
2. 需要追加cluster的host，而不仅仅是更新
   + clustermanager和cluster adapter增加相关接口