### PR TITLE
Fix reset event  cause deadlock

### DIFF
--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -62,6 +62,7 @@ func TestLogPrintnull(t *testing.T) {
 	buf.WriteString("")
 	l.Print(buf, false)
 	l.Close()
+	time.Sleep(time.Second)
 	f, _ := os.Open(logName)
 	b := make([]byte, 1024)
 	n, _ := f.Read(b)

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -86,6 +86,7 @@ type downStream struct {
 	downstreamReset   uint32
 	downstreamCleaned uint32
 	upstreamReset     uint32
+	reuseBuffer       uint32
 
 	// ~~~ filters
 	senderFilters   []*activeStreamSenderFilter
@@ -119,6 +120,7 @@ func newActiveStream(ctx context.Context, proxy *proxy, responseSender types.Str
 	stream.responseSender = responseSender
 	stream.responseSender.GetStream().AddEventListener(stream)
 	stream.context = ctx
+	stream.reuseBuffer = 1
 
 	stream.logger = log.ByContext(proxy.context)
 
@@ -132,25 +134,13 @@ func newActiveStream(ctx context.Context, proxy *proxy, responseSender types.Str
 	return stream
 }
 
-// case 1: downstream's lifecycle ends normally
-// case 2: downstream got reset. See downStream.resetStream for more detail
+// downstream's lifecycle ends normally
 func (s *downStream) endStream() {
-	var isReset bool
-	if s.responseSender != nil {
-		if !s.downstreamRecvDone || !s.upstreamProcessDone {
-			// if downstream req received not done, or local proxy process not done by handle upstream response,
-			// just mark it as done and reset stream as a failed case
-			s.upstreamProcessDone = true
-
-			// reset downstream will trigger a clean up, see OnResetStream
-			s.responseSender.GetStream().ResetStream(types.StreamLocalReset)
-			isReset = true
-		}
+	if s.responseSender != nil && !s.downstreamRecvDone {
+		// not reuse buffer
+		atomic.StoreUint32(&s.reuseBuffer, 0)
 	}
-
-	if !isReset {
-		s.cleanStream()
-	}
+	s.cleanStream()
 
 	// note: if proxy logic resets the stream, there maybe some underlying data in the conn.
 	// we ignore this for now, fix as a todo
@@ -168,7 +158,8 @@ func (s *downStream) cleanStream() {
 	}
 
 	// reset corresponding upstream stream
-	if s.upstreamRequest != nil {
+	if s.upstreamRequest != nil && !s.upstreamProcessDone {
+		s.upstreamProcessDone = true
 		s.upstreamRequest.resetStream()
 	}
 
@@ -223,7 +214,7 @@ func (s *downStream) OnResetStream(reason types.StreamResetReason) {
 		handle: func() {
 			s.ResetStream(reason)
 		},
-	})
+	}, false)
 }
 
 func (s *downStream) ResetStream(reason types.StreamResetReason) {
@@ -243,7 +234,7 @@ func (s *downStream) OnReceiveHeaders(context context.Context, headers types.Hea
 		handle: func() {
 			s.ReceiveHeaders(headers, endStream)
 		},
-	})
+	}, true)
 }
 
 func (s *downStream) ReceiveHeaders(headers types.HeaderMap, endStream bool) {
@@ -380,7 +371,7 @@ func (s *downStream) OnReceiveData(context context.Context, data types.IoBuffer,
 		handle: func() {
 			s.ReceiveData(s.downstreamReqDataBuf, endStream)
 		},
-	})
+	}, true)
 }
 
 func (s *downStream) ReceiveData(data types.IoBuffer, endStream bool) {
@@ -423,7 +414,7 @@ func (s *downStream) OnReceiveTrailers(context context.Context, trailers types.H
 		handle: func() {
 			s.ReceiveTrailers(trailers)
 		},
-	})
+	},true)
 }
 
 func (s *downStream) ReceiveTrailers(trailers types.HeaderMap) {
@@ -502,10 +493,10 @@ func (s *downStream) onResponseTimeout() {
 			s.upstreamRequest.host.HostStats().UpstreamRequestTimeout.Inc(1)
 		}
 
+		atomic.StoreUint32(&s.reuseBuffer, 0)
 		s.upstreamRequest.resetStream()
+		s.upstreamRequest.OnResetStream(types.UpstreamGlobalTimeout)
 	}
-
-	s.onUpstreamReset(UpstreamGlobalTimeout, types.StreamLocalReset)
 }
 
 func (s *downStream) setupPerReqTimeout() {
@@ -533,9 +524,10 @@ func (s *downStream) onPerReqTimeout() {
 			s.upstreamRequest.host.HostStats().UpstreamRequestTimeout.Inc(1)
 		}
 
+		atomic.StoreUint32(&s.reuseBuffer, 0)
 		s.upstreamRequest.resetStream()
 		s.requestInfo.SetResponseFlag(types.UpstreamRequestTimeout)
-		s.onUpstreamReset(UpstreamPerTryTimeout, types.StreamLocalReset)
+		s.upstreamRequest.OnResetStream(types.UpstreamPerTryTimeout)
 	} else {
 		log.DefaultLogger.Debugf("Skip request timeout on getting upstream response")
 	}
@@ -666,7 +658,7 @@ func (s *downStream) doAppendTrailers(filter *activeStreamSenderFilter, trailers
 }
 
 // ~~~ upstream event handler
-func (s *downStream) onUpstreamReset(urtype UpstreamResetType, reason types.StreamResetReason) {
+func (s *downStream) onUpstreamReset(reason types.StreamResetReason) {
 	if !atomic.CompareAndSwapUint32(&s.upstreamReset, 0, 1) {
 		return
 	}
@@ -675,7 +667,7 @@ func (s *downStream) onUpstreamReset(urtype UpstreamResetType, reason types.Stre
 	log.DefaultLogger.Tracef("on upstream reset invoked")
 
 	// see if we need a retry
-	if urtype != UpstreamGlobalTimeout &&
+	if reason != types.UpstreamGlobalTimeout &&
 		!s.downstreamResponseStarted && s.retryState != nil {
 		retryCheck := s.retryState.retry(nil, reason, s.doRetry)
 
@@ -711,7 +703,7 @@ func (s *downStream) onUpstreamReset(urtype UpstreamResetType, reason types.Stre
 		// send err response if response not started
 		var code int
 
-		if urtype == UpstreamGlobalTimeout || urtype == UpstreamPerTryTimeout {
+		if reason == types.UpstreamGlobalTimeout || reason == types.UpstreamPerTryTimeout {
 			s.requestInfo.SetResponseFlag(types.UpstreamRequestTimeout)
 			code = types.TimeoutExceptionCode
 		} else {
@@ -867,7 +859,14 @@ func (s *downStream) doRetry() {
 // 1. downstream filter reset downstream
 // 2. corresponding upstream got reset
 func (s *downStream) resetStream() {
-	s.endStream()
+	if s.responseSender != nil && !s.upstreamProcessDone {
+		// if downstream req received not done, or local proxy process not done by handle upstream response,
+		// just mark it as done and reset stream as a failed case
+		s.upstreamProcessDone = true
+
+		// reset downstream will trigger a clean up, see OnResetStream
+		s.responseSender.GetStream().ResetStream(types.StreamLocalReset)
+	}
 }
 
 func (s *downStream) sendHijackReply(code int, headers types.HeaderMap) {
@@ -975,6 +974,9 @@ func (s *downStream) DownstreamHeaders() types.HeaderMap {
 func (s *downStream) giveStream() {
 	if s.snapshot != nil {
 		s.proxy.clusterManager.PutClusterSnapshot(s.snapshot)
+	}
+	if atomic.LoadUint32(&s.reuseBuffer) != 1 {
+		return
 	}
 	if atomic.LoadUint32(&s.upstreamReset) == 1 || atomic.LoadUint32(&s.downstreamReset) == 1 {
 		return

--- a/pkg/proxy/downstream_test.go
+++ b/pkg/proxy/downstream_test.go
@@ -128,6 +128,8 @@ func TestDirectResponse(t *testing.T) {
 				},
 				clusterManager: &mockClusterManager{},
 				readCallbacks:  &mockReadFilterCallbacks{},
+				stats:          globalStats,
+				listenerStats:  newListenerStats("test"),
 			},
 			logger:         log.DefaultLogger,
 			responseSender: tc.client,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -55,8 +55,8 @@ func init() {
 func initWorkePpool(data interface{}, endParsing bool) error {
 	// default shardsNum is equal to the cpu num
 	shardsNum := runtime.NumCPU()
-	// use 4096 as chan buffer length
-	poolSize := shardsNum * 4096
+	// use 32768 as chan buffer length
+	poolSize := shardsNum * 32768
 
 	// set shardsNum equal to processor if it was specified
 	if pNum, ok := data.(int); ok && pNum > 0 {

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -55,13 +55,3 @@ const (
 	ResourceLimitExceeded UpstreamFailureReason = "ResourceLimitExceeded"
 	NoRoute               UpstreamFailureReason = "NoRoute"
 )
-
-// UpstreamResetType
-type UpstreamResetType string
-
-// Group of Upstream Reset Type
-const (
-	UpstreamReset         UpstreamResetType = "UpstreamReset"
-	UpstreamGlobalTimeout UpstreamResetType = "UpstreamGlobalTimeout"
-	UpstreamPerTryTimeout UpstreamResetType = "UpstreamPerTryTimeout"
-)

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -72,7 +72,7 @@ func (r *upstreamRequest) OnResetStream(reason types.StreamResetReason) {
 		handle: func() {
 			r.ResetStream(reason)
 		},
-	})
+	}, false)
 }
 
 func (r *upstreamRequest) OnDestroyStream() {}
@@ -82,7 +82,7 @@ func (r *upstreamRequest) ResetStream(reason types.StreamResetReason) {
 
 	if !r.setupRetry {
 		// todo: check if we get a reset on encode request headers. e.g. send failed
-		r.downStream.onUpstreamReset(UpstreamReset, reason)
+		r.downStream.onUpstreamReset(reason)
 	}
 }
 
@@ -104,7 +104,7 @@ func (r *upstreamRequest) OnReceiveHeaders(context context.Context, headers type
 		handle: func() {
 			r.ReceiveHeaders(headers, endStream)
 		},
-	})
+	}, true)
 }
 
 func (r *upstreamRequest) ReceiveHeaders(headers types.HeaderMap, endStream bool) {
@@ -127,7 +127,7 @@ func (r *upstreamRequest) OnReceiveData(context context.Context, data types.IoBu
 		handle: func() {
 			r.ReceiveData(r.downStream.downstreamRespDataBuf, endStream)
 		},
-	})
+	}, true)
 }
 
 func (r *upstreamRequest) ReceiveData(data types.IoBuffer, endStream bool) {
@@ -148,7 +148,7 @@ func (r *upstreamRequest) OnReceiveTrailers(context context.Context, trailers ty
 		handle: func() {
 			r.ReceiveTrailers(trailers)
 		},
-	})
+	}, true)
 }
 
 func (r *upstreamRequest) ReceiveTrailers(trailers types.HeaderMap) {

--- a/pkg/sync/types.go
+++ b/pkg/sync/types.go
@@ -43,7 +43,7 @@ type ShardWorkerPool interface {
 	Shard(source uint32) uint32
 
 	// Offer puts the job into the corresponding shard and execute it.
-	Offer(job ShardJob)
+	Offer(job ShardJob, block bool)
 }
 
 // WorkerPool provides a pool for goroutines

--- a/pkg/sync/workerpool_test.go
+++ b/pkg/sync/workerpool_test.go
@@ -76,7 +76,7 @@ func TestJobOrder(t *testing.T) {
 		counter := uint32(i)
 		go func() {
 			for j := 0; j < shardEvents; j++ {
-				pool.Offer(&TestJob{i: atomic.AddUint32(&counter, uint32(shardsNum))})
+				pool.Offer(&TestJob{i: atomic.AddUint32(&counter, uint32(shardsNum))}, true)
 			}
 		}()
 	}
@@ -124,7 +124,7 @@ func eventProcess(b *testing.B) {
 		counter := uint32(i)
 		go func() {
 			for j := 0; j < shardEvents; j++ {
-				pool.Offer(&TestJob{i: atomic.AddUint32(&counter, uint32(shardsNum))})
+				pool.Offer(&TestJob{i: atomic.AddUint32(&counter, uint32(shardsNum))}, true)
 			}
 		}()
 	}

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -100,6 +100,9 @@ const (
 	StreamLocalReset            StreamResetReason = "StreamLocalReset"
 	StreamOverflow              StreamResetReason = "StreamOverflow"
 	StreamRemoteReset           StreamResetReason = "StreamRemoteReset"
+	UpstreamReset               StreamResetReason = "UpstreamReset"
+	UpstreamGlobalTimeout       StreamResetReason = "UpstreamGlobalTimeout"
+	UpstreamPerTryTimeout       StreamResetReason = "UpstreamPerTryTimeout"
 )
 
 // Stream is a generic protocol stream, it is the core model in stream layer


### PR DESCRIPTION
### Issues associated with this PR

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions

* 新增reuseBuffer标， 表示是否回收复用downstream等结构体，默认复用。
* 当sendHijackReply等直接回复请求的场景，endStream()将走入reset逻辑, 这儿已经正常回复了，不需要再次reset流程，但是需要把reuseBuffer置为0，防止内存被回收，导致ReceiveData出错。
* requestTimeout和responseTimeout修改为event触发模式，避免协程并发冲突，然后置位reuseBuffer为0，不回收内存。
* Offer()新增block参数，表示是否阻塞操作，对于reset操作可以丢弃，避免死锁


### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
