### PR TITLE
Fix time format

### DIFF
--- a/pkg/log/accesslog.go
+++ b/pkg/log/accesslog.go
@@ -251,7 +251,7 @@ func formatToFormatter(format string) []types.AccessLogFormatter {
 // StartTimeGetter
 // get request's arriving time
 func StartTimeGetter(info types.RequestInfo) string {
-	return info.StartTime().Format("2006/01/02 15:04:05.999")
+	return info.StartTime().Format("2006/01/02 15:04:05.000")
 }
 
 // ReceivedDurationGetter

--- a/pkg/log/accesslog_test.go
+++ b/pkg/log/accesslog_test.go
@@ -78,6 +78,15 @@ func TestAccessLog(t *testing.T) {
 	}
 }
 
+func TestAccessLogStartTime(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		time.Sleep(time.Millisecond)
+		now := time.Now()
+		t.Log(now.Format("2006/01/02 15:04:05.999"))
+		t.Log(now.Format("2006/01/02 15:04:05.000"))
+	}
+}
+
 func BenchmarkAccessLog(b *testing.B) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	InitDefaultLogger("", INFO)


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
	accesslog_test.go:85: 2018/12/27 09:43:40.86
	accesslog_test.go:86: 2018/12/27 09:43:40.860
通过TestAccessLogStartTime()测试用例， 之前的用法会导致去掉后缀0
https://golang.org/src/time/format.go
golang的time fromat必须精确限定日期数字。
```
	stdFracSecond0                                 // ".0", ".00", ... , trailing zeros included
	stdFracSecond9                                 // ".9", ".99", ..., trailing zeros omitted
```
* .000 表示包含后缀0
* .999 表示删除后缀0


### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
