### PR TITLE
fix metrics transfer timeout

### DIFF
--- a/pkg/metrics/transfer.go
+++ b/pkg/metrics/transfer.go
@@ -181,7 +181,7 @@ func TransferServer(gracefultime time.Duration, ch chan<- bool) {
 		}
 	}()
 	select {
-	case <-time.After(gracefultime*2 + time.Second*10):
+	case <-time.After(2 * (gracefultime + types.DefaultConnReadTimeout)):
 		log.DefaultLogger.Infof("transfer metrics server exit")
 	}
 }


### PR DESCRIPTION
read timeout的超时延长以后，所有热升级迁移的等待时间也应该延长
之前同步修改了connection transfer的数据，遗漏了metrics迁移的等待时间