### PR TITLE
fix #486

### DIFF
--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -322,8 +322,8 @@ func (conn *serverStreamConnection) handleFrame(ctx context.Context, i interface
 			conn.logger.Debugf("http2 server data: %d", id)
 			stream.receiver.OnReceiveData(stream.ctx, stream.buildData(), false)
 		}
-		trailer := mhttp2.NewHeaderMap(h2s.Request.Trailer)
-		conn.logger.Debugf("http2 server trailer: %d, %v", id, h2s.Request.Trailer)
+		trailer := mhttp2.NewHeaderMap(stream.h2s.Request.Trailer)
+		conn.logger.Debugf("http2 server trailer: %d, %v", id, stream.h2s.Request.Trailer)
 		stream.receiver.OnReceiveTrailers(ctx, trailer)
 		return
 	}


### PR DESCRIPTION
http2 server stream 的handleFrame, 是收到client的处理，收到header的时候 会把相关的信息记录在stream中，后续解析应该用stream中的数据