### PR TITLE
Proxy gateway

### DIFF
--- a/pkg/api/v2/config.go
+++ b/pkg/api/v2/config.go
@@ -92,6 +92,7 @@ type RouterConfig struct {
 
 type RouterActionConfig struct {
 	ClusterName             string               `json:"cluster_name"`
+	UpstreamProtocol        string               `json:"upstream_protocol"`
 	ClusterHeader           string               `json:"cluster_header"`
 	WeightedClusters        []WeightedCluster    `json:"weighted_clusters"`
 	MetadataConfig          MetadataConfig       `json:"metadata_match"`

--- a/pkg/protocol/rpc/sofarpc/conv.go
+++ b/pkg/protocol/rpc/sofarpc/conv.go
@@ -92,6 +92,10 @@ func MapToFields(ctx context.Context, cmd SofaRpcCmd) (map[string]string, error)
 type common2sofa struct{}
 
 func (c *common2sofa) ConvHeader(ctx context.Context, headerMap types.HeaderMap) (types.HeaderMap, error) {
+	if _, ok := headerMap.(SofaRpcCmd); ok {
+		// do not need to convert
+		return headerMap, nil
+	}
 	if header, ok := headerMap.(protocol.CommonHeader); ok {
 		return MapToCmd(ctx, header)
 	}
@@ -110,6 +114,10 @@ func (c *common2sofa) ConvTrailer(ctx context.Context, headerMap types.HeaderMap
 type sofa2common struct{}
 
 func (c *sofa2common) ConvHeader(ctx context.Context, headerMap types.HeaderMap) (types.HeaderMap, error) {
+	if _, ok := headerMap.(protocol.CommonHeader); ok {
+		// do not need to convert
+		return headerMap, nil
+	}
 	if cmd, ok := headerMap.(SofaRpcCmd); ok {
 		header, err := MapToFields(ctx, cmd)
 		return protocol.CommonHeader(header), err

--- a/pkg/proxy/mock_test.go
+++ b/pkg/proxy/mock_test.go
@@ -76,6 +76,10 @@ func (r *mockRouteRule) ClusterName() string {
 	return "test"
 }
 
+func (r *mockRouteRule) UpstreamProtocol() string {
+	return ""
+}
+
 type mockDirectRule struct {
 	status int
 	body   string

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	"github.com/alipay/sofa-mosn/pkg/config"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/mtls"
 	"github.com/alipay/sofa-mosn/pkg/protocol"
@@ -33,7 +34,6 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/types"
 	"github.com/json-iterator/go"
 	"github.com/rcrowley/go-metrics"
-	"github.com/alipay/sofa-mosn/pkg/config"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -261,17 +261,4 @@ type downstreamCallbacks struct {
 
 func (dc *downstreamCallbacks) OnEvent(event types.ConnectionEvent) {
 	dc.proxy.onDownstreamEvent(event)
-}
-
-func (p *proxy) convertProtocol() (dp, up types.Protocol) {
-	if p.serverStreamConn == nil {
-		dp = types.Protocol(p.config.DownstreamProtocol)
-	} else {
-		dp = p.serverStreamConn.Protocol()
-	}
-	up = types.Protocol(p.config.UpstreamProtocol)
-	if up == protocol.Auto {
-		up = dp
-	}
-	return
 }

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -491,7 +491,10 @@ func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
 }
 
 func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
-	f.activeStream.downstreamReqDataBuf = data
+	// same as downstream OnReceiveData
+	f.activeStream.downstreamReqDataBuf = data.Clone()
+	f.activeStream.downstreamReqDataBuf.Count(1)
+	data.Drain(data.Len())
 }
 
 func (f *activeStreamReceiverFilter) GetRequestTrailers() types.HeaderMap {
@@ -515,7 +518,9 @@ func (f *activeStreamSenderFilter) GetResponseData() types.IoBuffer {
 }
 
 func (f *activeStreamSenderFilter) SetResponseData(data types.IoBuffer) {
-	f.activeStream.downstreamRespDataBuf = data
+	// same as upstream OnReceiveData
+	f.activeStream.downstreamRespDataBuf = data.Clone()
+	data.Drain(data.Len())
 }
 
 func (f *activeStreamSenderFilter) GetResponseTrailers() types.HeaderMap {

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -364,28 +364,6 @@ func (f *activeStreamReceiverFilter) SendHijackReply(code int, headers types.Hea
 	f.activeStream.sendHijackReply(code, headers)
 }
 
-func (f *activeStreamReceiverFilter) GetRequestHeaders() types.HeaderMap {
-	return f.activeStream.downstreamReqHeaders
-}
-func (f *activeStreamReceiverFilter) SetRequestHeaders(headers types.HeaderMap) {
-	f.activeStream.downstreamReqHeaders = headers
-}
-func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
-	return f.activeStream.downstreamReqDataBuf
-}
-
-func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
-	f.activeStream.downstreamReqDataBuf = data
-}
-
-func (f *activeStreamReceiverFilter) GetRequestTrailers() types.HeaderMap {
-	return f.activeStream.downstreamReqTrailers
-}
-
-func (f *activeStreamReceiverFilter) SetRequestTrailers(trailers types.HeaderMap) {
-	f.activeStream.downstreamReqTrailers = trailers
-}
-
 // types.StreamSenderFilterHandler
 type activeStreamSenderFilter struct {
 	activeStreamFilter
@@ -499,6 +477,29 @@ func (f *activeStreamSenderFilter) handleBufferData(buf types.IoBuffer) {
 
 		f.activeStream.downstreamRespDataBuf.ReadFrom(buf)
 	}
+}
+
+// TODO: remove all of the following when proxy changed to single request @lieyuan
+func (f *activeStreamReceiverFilter) GetRequestHeaders() types.HeaderMap {
+	return f.activeStream.downstreamReqHeaders
+}
+func (f *activeStreamReceiverFilter) SetRequestHeaders(headers types.HeaderMap) {
+	f.activeStream.downstreamReqHeaders = headers
+}
+func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
+	return f.activeStream.downstreamReqDataBuf
+}
+
+func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
+	f.activeStream.downstreamReqDataBuf = data
+}
+
+func (f *activeStreamReceiverFilter) GetRequestTrailers() types.HeaderMap {
+	return f.activeStream.downstreamReqTrailers
+}
+
+func (f *activeStreamReceiverFilter) SetRequestTrailers(trailers types.HeaderMap) {
+	f.activeStream.downstreamReqTrailers = trailers
 }
 
 func (f *activeStreamSenderFilter) GetResponseHeaders() types.HeaderMap {

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -324,6 +324,7 @@ func (f *activeStreamReceiverFilter) doContinue() {
 	if hasBuffedData || f.stoppedNoBuf {
 		if f.stoppedNoBuf || f.activeStream.downstreamReqDataBuf == nil {
 			f.activeStream.downstreamReqDataBuf = buffer.NewIoBuffer(0)
+			f.activeStream.downstreamReqDataBuf.Count(1)
 		}
 
 		endStream := f.activeStream.downstreamRecvDone && !hasTrailer
@@ -339,6 +340,7 @@ func (f *activeStreamReceiverFilter) handleBufferData(buf types.IoBuffer) {
 	if f.activeStream.downstreamReqDataBuf != buf {
 		if f.activeStream.downstreamReqDataBuf == nil {
 			f.activeStream.downstreamReqDataBuf = buffer.NewIoBuffer(buf.Len())
+			f.activeStream.downstreamReqDataBuf.Count(1)
 		}
 
 		f.activeStream.downstreamReqDataBuf.ReadFrom(buf)
@@ -497,6 +499,7 @@ func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
 	}
 	if f.activeStream.downstreamReqDataBuf == nil {
 		f.activeStream.downstreamReqDataBuf = buffer.NewIoBuffer(0)
+		f.activeStream.downstreamReqDataBuf.Count(1)
 	}
 	f.activeStream.downstreamReqDataBuf.Reset()
 	f.activeStream.downstreamReqDataBuf.ReadFrom(data)

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -491,10 +491,11 @@ func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
 }
 
 func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
-	// same as downstream OnReceiveData
-	f.activeStream.downstreamReqDataBuf = data.Clone()
-	f.activeStream.downstreamReqDataBuf.Count(1)
-	data.Drain(data.Len())
+	if f.activeStream.downstreamReqDataBuf == nil {
+		f.activeStream.downstreamReqDataBuf = buffer.NewIoBuffer(0)
+	}
+	f.activeStream.downstreamReqDataBuf.Reset()
+	f.activeStream.downstreamReqDataBuf.ReadFrom(data)
 }
 
 func (f *activeStreamReceiverFilter) GetRequestTrailers() types.HeaderMap {
@@ -518,9 +519,11 @@ func (f *activeStreamSenderFilter) GetResponseData() types.IoBuffer {
 }
 
 func (f *activeStreamSenderFilter) SetResponseData(data types.IoBuffer) {
-	// same as upstream OnReceiveData
-	f.activeStream.downstreamRespDataBuf = data.Clone()
-	data.Drain(data.Len())
+	if f.activeStream.downstreamRespDataBuf == nil {
+		f.activeStream.downstreamRespDataBuf = buffer.NewIoBuffer(0)
+	}
+	f.activeStream.downstreamRespDataBuf.Reset()
+	f.activeStream.downstreamRespDataBuf.ReadFrom(data)
 }
 
 func (f *activeStreamSenderFilter) GetResponseTrailers() types.HeaderMap {

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -225,6 +225,7 @@ func (f *activeStreamFilter) RequestInfo() types.RequestInfo {
 	return f.activeStream.requestInfo
 }
 
+// types.StreamReceiverFilter
 // types.StreamReceiverFilterHandler
 type activeStreamReceiverFilter struct {
 	activeStreamFilter
@@ -350,6 +351,7 @@ func (f *activeStreamReceiverFilter) AppendHeaders(headers types.HeaderMap, endS
 }
 
 func (f *activeStreamReceiverFilter) AppendData(buf types.IoBuffer, endStream bool) {
+	f.activeStream.downstreamRespDataBuf = buf
 	f.activeStream.doAppendData(nil, buf, endStream)
 }
 
@@ -360,6 +362,28 @@ func (f *activeStreamReceiverFilter) AppendTrailers(trailers types.HeaderMap) {
 
 func (f *activeStreamReceiverFilter) SendHijackReply(code int, headers types.HeaderMap) {
 	f.activeStream.sendHijackReply(code, headers)
+}
+
+func (f *activeStreamReceiverFilter) GetRequestHeaders() types.HeaderMap {
+	return f.activeStream.downstreamReqHeaders
+}
+func (f *activeStreamReceiverFilter) SetRequestHeaders(headers types.HeaderMap) {
+	f.activeStream.downstreamReqHeaders = headers
+}
+func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
+	return f.activeStream.downstreamReqDataBuf
+}
+
+func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
+	f.activeStream.downstreamReqDataBuf = data
+}
+
+func (f *activeStreamReceiverFilter) GetRequestTrailers() types.HeaderMap {
+	return f.activeStream.downstreamReqTrailers
+}
+
+func (f *activeStreamReceiverFilter) SetRequestTrailers(trailers types.HeaderMap) {
+	f.activeStream.downstreamReqTrailers = trailers
 }
 
 // types.StreamSenderFilterHandler
@@ -475,4 +499,28 @@ func (f *activeStreamSenderFilter) handleBufferData(buf types.IoBuffer) {
 
 		f.activeStream.downstreamRespDataBuf.ReadFrom(buf)
 	}
+}
+
+func (f *activeStreamSenderFilter) GetResponseHeaders() types.HeaderMap {
+	return f.activeStream.downstreamRespHeaders
+}
+
+func (f *activeStreamSenderFilter) SetResponseHeaders(headers types.HeaderMap) {
+	f.activeStream.downstreamRespHeaders = headers
+}
+
+func (f *activeStreamSenderFilter) GetResponseData() types.IoBuffer {
+	return f.activeStream.downstreamRespDataBuf
+}
+
+func (f *activeStreamSenderFilter) SetResponseData(data types.IoBuffer) {
+	f.activeStream.downstreamRespDataBuf = data
+}
+
+func (f *activeStreamSenderFilter) GetResponseTrailers() types.HeaderMap {
+	return f.activeStream.downstreamRespTrailers
+}
+
+func (f *activeStreamSenderFilter) SetResponseTrailers(trailers types.HeaderMap) {
+	f.activeStream.downstreamRespTrailers = trailers
 }

--- a/pkg/proxy/streamfilters.go
+++ b/pkg/proxy/streamfilters.go
@@ -491,6 +491,10 @@ func (f *activeStreamReceiverFilter) GetRequestData() types.IoBuffer {
 }
 
 func (f *activeStreamReceiverFilter) SetRequestData(data types.IoBuffer) {
+	// data is the original data. do nothing
+	if f.activeStream.downstreamReqDataBuf == data {
+		return
+	}
 	if f.activeStream.downstreamReqDataBuf == nil {
 		f.activeStream.downstreamReqDataBuf = buffer.NewIoBuffer(0)
 	}
@@ -519,6 +523,10 @@ func (f *activeStreamSenderFilter) GetResponseData() types.IoBuffer {
 }
 
 func (f *activeStreamSenderFilter) SetResponseData(data types.IoBuffer) {
+	// data is the original data. do nothing
+	if f.activeStream.downstreamRespDataBuf == data {
+		return
+	}
 	if f.activeStream.downstreamRespDataBuf == nil {
 		f.activeStream.downstreamRespDataBuf = buffer.NewIoBuffer(0)
 	}

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -206,7 +206,7 @@ func (r *upstreamRequest) appendHeaders(headers types.HeaderMap, endStream bool)
 }
 
 func (r *upstreamRequest) convertHeader(headers types.HeaderMap) types.HeaderMap {
-	dp, up := r.proxy.convertProtocol()
+	dp, up := r.downStream.convertProtocol()
 
 	// need protocol convert
 	if dp != up {
@@ -227,7 +227,7 @@ func (r *upstreamRequest) appendData(data types.IoBuffer, endStream bool) {
 }
 
 func (r *upstreamRequest) convertData(data types.IoBuffer) types.IoBuffer {
-	dp, up := r.proxy.convertProtocol()
+	dp, up := r.downStream.convertProtocol()
 
 	// need protocol convert
 	if dp != up {
@@ -248,7 +248,7 @@ func (r *upstreamRequest) appendTrailers(trailers types.HeaderMap) {
 }
 
 func (r *upstreamRequest) convertTrailer(trailers types.HeaderMap) types.HeaderMap {
-	dp, up := r.proxy.convertProtocol()
+	dp, up := r.downStream.convertProtocol()
 
 	// need protocol convert
 	if dp != up {

--- a/pkg/router/routeruleimpl.go
+++ b/pkg/router/routeruleimpl.go
@@ -42,6 +42,7 @@ func NewRouteRuleImplBase(vHost *VirtualHostImpl, route *v2.Router) (*RouteRuleI
 		routerMatch:           route.Match,
 		routerAction:          route.Route,
 		clusterName:           route.Route.ClusterName,
+		upstreamProtocol:      route.Route.UpstreamProtocol,
 		randInstance:          rand.New(rand.NewSource(time.Now().UnixNano())),
 		configHeaders:         getRouterHeaders(route.Match.Headers),
 		prefixRewrite:         route.Route.PrefixRewrite,
@@ -91,6 +92,7 @@ type RouteRuleImplBase struct {
 	autoHostRewrite             bool
 	useWebSocket                bool
 	clusterName                 string //
+	upstreamProtocol            string
 	clusterHeaderName           lowerCaseString
 	clusterNotFoundResponseCode httpmosn.Code
 	timeout                     time.Duration
@@ -174,6 +176,10 @@ func (rri *RouteRuleImplBase) ClusterName() string {
 
 	log.DefaultLogger.Errorf("Something wrong when choosing weighted cluster")
 	return rri.clusterName
+}
+
+func (rri *RouteRuleImplBase) UpstreamProtocol() string {
+	return rri.upstreamProtocol
 }
 
 func (rri *RouteRuleImplBase) GlobalTimeout() time.Duration {

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -97,6 +97,10 @@ type RouteRule interface {
 	// ClusterName returns the route's cluster name
 	ClusterName() string
 
+	// UpstreamProtocol returns the protocol that route's cluster supported
+	// If it is configured, the protocol will replace the proxy config's upstream protocol
+	UpstreamProtocol() string
+
 	// GlobalTimeout returns the global timeout
 	GlobalTimeout() time.Duration
 

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -264,6 +264,8 @@ type StreamSenderFilterHandler interface {
 
 	// ContinueSending continue iterating through the filter chain with buffered headers and body data
 	ContinueSending()
+
+	// TODO :remove all of the following when proxy changed to single request @lieyuan
 	// StreamFilters will modified headers/data/trailer in different steps
 	// for example, maybe modify headers in AppendData
 	GetResponseHeaders() HeaderMap
@@ -324,6 +326,7 @@ type StreamReceiverFilterHandler interface {
 	// SendHijackReply is called when the filter will response directly
 	SendHijackReply(code int, headers HeaderMap)
 
+	// TODO: remove all of the following when proxy changed to single request @lieyuan
 	// StreamFilters will modified headers/data/trailer in different steps
 	// for example, maybe modify headers in on receive data
 	GetRequestHeaders() HeaderMap

--- a/pkg/types/stream.go
+++ b/pkg/types/stream.go
@@ -264,6 +264,16 @@ type StreamSenderFilterHandler interface {
 
 	// ContinueSending continue iterating through the filter chain with buffered headers and body data
 	ContinueSending()
+	// StreamFilters will modified headers/data/trailer in different steps
+	// for example, maybe modify headers in AppendData
+	GetResponseHeaders() HeaderMap
+	SetResponseHeaders(headers HeaderMap)
+
+	GetResponseData() IoBuffer
+	SetResponseData(buf IoBuffer)
+
+	GetResponseTrailers() HeaderMap
+	SetResponseTrailers(trailers HeaderMap)
 }
 
 // StreamReceiverFilter is a StreamFilterBase wrapper
@@ -295,6 +305,8 @@ type StreamReceiverFilterHandler interface {
 	// The controller will dispatch headers and any buffered body data to the next filter in the chain.
 	ContinueReceiving()
 
+	// TODO: consider receiver filter needs AppendXXX or not
+
 	// AppendHeaders is called with headers to be encoded, optionally indicating end of stream
 	// Filter uses this function to send out request/response headers of the stream
 	// endStream supplies whether this is a header only request/response
@@ -311,6 +323,17 @@ type StreamReceiverFilterHandler interface {
 
 	// SendHijackReply is called when the filter will response directly
 	SendHijackReply(code int, headers HeaderMap)
+
+	// StreamFilters will modified headers/data/trailer in different steps
+	// for example, maybe modify headers in on receive data
+	GetRequestHeaders() HeaderMap
+	SetRequestHeaders(headers HeaderMap)
+
+	GetRequestData() IoBuffer
+	SetRequestData(buf IoBuffer)
+
+	GetRequestTrailers() HeaderMap
+	SetRequestTrailers(trailers HeaderMap)
 }
 
 // StreamFilterChainFactory adds filter into callbacks


### PR DESCRIPTION
一些为网关做的临时改动

+ ReceiveFilterHandler和SenderFilterHandler 暴露stream的Header、Data、Trailer相关的接口，这部分内容需要在proxy重构以后 考虑删除/修改掉

+ 支持Router级别的Upstream协议覆盖Proxy级别的协议
   + convert protocol 修改到downstream 级别
  + 如果Router没有配置对应的协议，则依然使用Proxy级别的协议