### PR TITLE
fix ci, go test may exit 1 directly

### DIFF
--- a/etc/script/report.sh
+++ b/etc/script/report.sh
@@ -5,14 +5,8 @@ echo "" > coverage.txt
 
 for d in $(go list ./pkg/...); do
     echo "--------Run test package: $d"
-    output="$(go test -v -coverprofile=profile.out -covermode=atomic $d)"
-    echo "$output"
-    fail=$(echo "$output" | grep "\-\-\- FAIL:" | wc -l)
+    go test -v -coverprofile=profile.out -covermode=atomic $d
     echo "--------Finish test package: $d"
-    if [ $fail -ne 0 ]; then
-	    echo "-------Package $d test FAILED"
-	    exit 1
-    fi
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out


### PR DESCRIPTION
CI 检查有时不会返回错误，原因是go test可能直接exit 1了， 捕获的输出还来不及echo