### PR TITLE
do not set request.Content if content length is 0

### DIFF
--- a/pkg/protocol/rpc/sofarpc/codec/boltv1.go
+++ b/pkg/protocol/rpc/sofarpc/codec/boltv1.go
@@ -243,7 +243,10 @@ func (c *boltCodec) Decode(ctx context.Context, data types.IoBuffer) (interface{
 				request.ContentLen = int(contentLen)
 				request.ClassName = class
 				request.HeaderMap = header
-				request.Content = buffer.NewIoBufferBytes(content)
+				// avoid valid IoBuffer with empty buffer
+				if content != nil {
+					request.Content = buffer.NewIoBufferBytes(content)
+				}
 				sofarpc.DeserializeBoltRequest(ctx, request)
 
 				cmd = request


### PR DESCRIPTION
### Issues associated with this PR

#500 

### Solutions
Do not set request.Content if content length is 0, so sofarpc heartbeat won't trigger OnReceiveData any more.
