### PR TITLE
Fix heartbeatfilter

### DIFF
--- a/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
+++ b/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
@@ -73,8 +73,6 @@ func (f *healthCheckFilter) OnReceiveHeaders(headers types.HeaderMap, endStream 
 			if !f.passThrough {
 				f.intercept = true
 			}
-
-			endStream = true
 		}
 	}
 


### PR DESCRIPTION
原来的代码中，没有办法区分RPC的请求是否有Body，因此RPC中OnReceiveHeader的endstream 永远都是false，但是RPC心跳只有Header。 为了对应这种情况，在心跳拦截的处理中做了HACK，认为心跳的endStream一定是true。
如今的代码已经可以区分这个endStream了，不需要强制修改