### PR TITLE
 fix io.EOF causes drop iobuffer

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -366,7 +366,7 @@ func (c *connection) doRead() (err error) {
 			if bytesRead == 0 {
 				return err
 			}
-		} else {
+		} else if err != io.EOF {
 			return err
 		}
 	}
@@ -375,9 +375,8 @@ func (c *connection) doRead() (err error) {
 		cb(uint64(bytesRead))
 	}
 
-	c.onRead(bytesRead)
+	c.onRead()
 	c.updateReadBufStats(bytesRead, int64(c.readBuffer.Len()))
-
 	return
 }
 
@@ -397,12 +396,12 @@ func (c *connection) updateReadBufStats(bytesRead int64, bytesBufSize int64) {
 	}
 }
 
-func (c *connection) onRead(bytesRead int64) {
+func (c *connection) onRead() {
 	if !c.readEnabled {
 		return
 	}
 
-	if bytesRead == 0 {
+	if c.readBuffer.Len() == 0 {
 		return
 	}
 


### PR DESCRIPTION
### Issues associated with this PR


### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
有很低的几率导致收到连接关闭的io.EOF之后, 丢弃最后收到的数据包.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
