### PR TITLE
fix fasthttp header returns empty string

### DIFF
--- a/pkg/protocol/http/types.go
+++ b/pkg/protocol/http/types.go
@@ -92,10 +92,11 @@ type RequestHeader struct {
 	*fasthttp.RequestHeader
 }
 
-// Get value of key
+// Get value of key, empty string means not exists
 func (h RequestHeader) Get(key string) (string, bool) {
 	result := h.Peek(key)
-	if result != nil {
+	// result is not nil, but the length is 0
+	if len(result) != 0 {
 		return string(result), true
 	}
 	return "", false
@@ -140,10 +141,11 @@ type ResponseHeader struct {
 	*fasthttp.ResponseHeader
 }
 
-// Get value of key
+// Get value of key, empty string means not exists
 func (h ResponseHeader) Get(key string) (string, bool) {
 	result := h.Peek(key)
-	if result != nil {
+	// result is not nil, but the length is 0
+	if len(result) != 0 {
 		return string(result), true
 	}
 	return "", false

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -667,7 +667,7 @@ func removeInternalHeaders(headers mosnhttp.RequestHeader, remoteAddr net.Addr) 
 	uri := ""
 
 	// path
-	if path, ok := headers.Get(protocol.MosnHeaderPathKey); ok {
+	if path, ok := headers.Get(protocol.MosnHeaderPathKey); ok && path != "" {
 		headers.Del(protocol.MosnHeaderPathKey)
 		uri += path
 	} else {
@@ -676,7 +676,7 @@ func removeInternalHeaders(headers mosnhttp.RequestHeader, remoteAddr net.Addr) 
 
 	// querystring
 	queryString, ok := headers.Get(protocol.MosnHeaderQueryStringKey)
-	if ok {
+	if ok && queryString != "" {
 		headers.Del(protocol.MosnHeaderQueryStringKey)
 		uri += "?" + queryString
 	}


### PR DESCRIPTION
fasthttp header 有时候会返回非空但是长度为0的值，导致http参数会不正确