### PR TITLE
record response status code as http code

### DIFF
--- a/pkg/istio/control/http/report_data.go
+++ b/pkg/istio/control/http/report_data.go
@@ -32,7 +32,7 @@ type ReportInfo struct {
 	responseTotalSize uint64
 	requestTotalSize  uint64
 	duration          time.Duration
-	responseCode      uint32
+	responseCode      int
 	requestBodySize   uint64
 	responseBodySize  uint64
 	responseFlag      types.ResponseFlag

--- a/pkg/log/accesslog_test.go
+++ b/pkg/log/accesslog_test.go
@@ -168,7 +168,7 @@ type mock_requestInfo struct {
 	requestFinishedDuration  time.Duration
 	bytesSent                uint64
 	bytesReceived            uint64
-	responseCode             uint32
+	responseCode             int
 	localAddress             net.Addr
 	downstreamLocalAddress   net.Addr
 	downstreamRemoteAddress  net.Addr
@@ -235,11 +235,11 @@ func (r *mock_requestInfo) Protocol() types.Protocol {
 	return r.protocol
 }
 
-func (r *mock_requestInfo) ResponseCode() uint32 {
+func (r *mock_requestInfo) ResponseCode() int {
 	return r.responseCode
 }
 
-func (r *mock_requestInfo) SetResponseCode(code uint32) {
+func (r *mock_requestInfo) SetResponseCode(code int) {
 	r.responseCode = code
 }
 

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -180,7 +180,7 @@ selectwriter:
 		//create parent dir if not exists
 		err := os.MkdirAll(filepath.Dir(l.Output), 0755)
 
-		fmt.Println(err)
+		//fmt.Println(err)
 
 		file, err = os.OpenFile(l.Output, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {

--- a/pkg/network/requestinfo.go
+++ b/pkg/network/requestinfo.go
@@ -35,7 +35,7 @@ type RequestInfo struct {
 	responseReceivedDuration time.Duration
 	bytesSent                uint64
 	bytesReceived            uint64
-	responseCode             uint32
+	responseCode             int
 	localAddress             net.Addr
 	downstreamLocalAddress   net.Addr
 	downstreamRemoteAddress  net.Addr
@@ -111,11 +111,11 @@ func (r *RequestInfo) Protocol() types.Protocol {
 	return r.protocol
 }
 
-func (r *RequestInfo) ResponseCode() uint32 {
+func (r *RequestInfo) ResponseCode() int {
 	return r.responseCode
 }
 
-func (r *RequestInfo) SetResponseCode(code uint32) {
+func (r *RequestInfo) SetResponseCode(code int) {
 	r.responseCode = code
 }
 

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -94,10 +94,13 @@ type RequestInfo interface {
 	Protocol() Protocol
 
 	// ResponseCode reports the request's response code
-	ResponseCode() uint32
+	// The code is http standard status code.
+	ResponseCode() int
 
 	// SetResponseCode set request's response code
-	SetResponseCode(code uint32)
+	// Mosn use http standard status code for log, if a protocol have different status code
+	// we will try to mapping it to http status code, and log it
+	SetResponseCode(code int)
 
 	// Duration reports the duration since request's starting time
 	Duration() time.Duration


### PR DESCRIPTION
1. 为了统一StatusCode处理情况，修改RequestInfo（用于AccessLog）中ResponseCode的语义，改为全部记录HTTP标准的StatusCode； RPC的StatusCode会映射为对应的StatusCode
2. SendHijack的时候需要设置ResponseCode
3. 修改Trace输出的位置，与AccessLog在同一个地方输出，保证每个请求都会有一个Trace
