### PR TITLE
Demo: host cache

### DIFF
--- a/pkg/admin/effectiveconfig_test.go
+++ b/pkg/admin/effectiveconfig_test.go
@@ -271,6 +271,9 @@ func TestSetClusterAndHosts(t *testing.T) {
 			if err := tc.expect(); err != nil {
 				t.Error(err)
 			}
+
+			b, _ := Dump()
+			t.Log(string(b))
 		})
 	}
 }

--- a/pkg/upstream/cluster/clustermanager.go
+++ b/pkg/upstream/cluster/clustermanager.go
@@ -166,7 +166,7 @@ func (pc *primaryCluster) UpdateHosts(hosts []types.Host) error {
 	for _, h := range hosts {
 		hostConfig = append(hostConfig, h.Config())
 	}
-	config.Hosts = hostConfig
+	config.Hosts = nil
 	pc.configUsed = config
 	if err := pc.configLock.Update(pc.configUsed, 0); err == rcu.Block {
 		return err

--- a/pkg/upstream/cluster/host_test.go
+++ b/pkg/upstream/cluster/host_test.go
@@ -76,3 +76,16 @@ func TestHostDisableTLS(t *testing.T) {
 		conn.Close(types.NoFlush, types.LocalClose)
 	}
 }
+
+func BenchmarkAddV2Host(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		addV2Host(host1.Address, host1)
+	}
+}
+
+func BenchmarkGetV2Host(b *testing.B) {
+	addV2Host(host1.Address, host1)
+	for n := 0; n < b.N; n++ {
+		getV2Host(host1.Address)
+	}
+}


### PR DESCRIPTION
### Issues associated with this PR

demo

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
当后端机器数多的时候, 将导致对象数很多, GC有一定压力
该demo主要是解决v2.Host产生的对象数, 原理就是gob系列化为[]byte, 然后保存在bigCache里面, 在使用的时候再反序列化. 达到减少对象数的目的, 在数据有更新的时候, CPU会有一定增加.
* 序列化一个v2.Host :  14us
* 反序列化一个v2.Host:  40us

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
func BenchmarkAddV2Host(b *testing.B) {
	for n := 0; n < b.N; n++ {
		addV2Host(host1.Address, host1)
	}
}

func BenchmarkGetV2Host(b *testing.B) {
	addV2Host(host1.Address, host1)
	for n := 0; n < b.N; n++ {
		getV2Host(host1.Address)
	}
}


### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
