### PR TITLE
inject sofarpc timeout, timeout config in header change to ms

### DIFF
--- a/pkg/protocol/rpc/sofarpc/types.go
+++ b/pkg/protocol/rpc/sofarpc/types.go
@@ -233,6 +233,10 @@ func (b *BoltRequest) SetData(data types.IoBuffer) {
 	b.Content = data
 }
 
+func (b *BoltRequest) GetTimeout() int {
+	return b.Timeout
+}
+
 // ~ SofaRpcCmd
 func (b *BoltRequest) CommandType() byte {
 	return b.CmdType
@@ -337,6 +341,11 @@ func (b *BoltResponse) SetHeader(header map[string]string) {
 
 func (b *BoltResponse) SetData(data types.IoBuffer) {
 	b.Content = data
+}
+
+// response have no timeout
+func (b *BoltResponse) GetTimeout() int {
+	return -1
 }
 
 // ~ ResponseStatus

--- a/pkg/protocol/rpc/types.go
+++ b/pkg/protocol/rpc/types.go
@@ -52,6 +52,8 @@ type RpcCmd interface {
 	SetHeader(header map[string]string)
 
 	SetData(data types.IoBuffer)
+
+	GetTimeout() int
 }
 
 // ResponseStatus describe that the model has the [response status] information

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -36,13 +36,13 @@ func parseProxyTimeout(route types.Route, headers types.HeaderMap) *Timeout {
 
 	if tto, ok := headers.Get(types.HeaderTryTimeout); ok {
 		if trytimeout, err := strconv.ParseInt(tto, 10, bitSize64); err == nil {
-			timeout.TryTimeout = time.Duration(trytimeout)
+			timeout.TryTimeout = time.Duration(trytimeout) * time.Millisecond
 		}
 	}
 
 	if gto, ok := headers.Get(types.HeaderGlobalTimeout); ok {
 		if globaltimeout, err := strconv.ParseInt(gto, 10, bitSize64); err == nil {
-			timeout.GlobalTimeout = time.Duration(globaltimeout)
+			timeout.GlobalTimeout = time.Duration(globaltimeout) * time.Millisecond
 		}
 	}
 


### PR DESCRIPTION
1. SofaRPC在Stream层支持注入Timeout
2. Timeout从Header中解析的值由ns改为ms

关于测试：

已经手动测试通过：

1. 路由配置中配置超时，超时符合预期
2. 请求中配置超时，SofaRPC注入，超时符合预期，且不会将注入的Key转发出去
3. HTTP请求中主动设置对应的Key，超时符合预期