### PR TITLE
Fix http tracer spanbuilder

### DIFF
--- a/pkg/stream/http/buffer.go
+++ b/pkg/stream/http/buffer.go
@@ -47,13 +47,13 @@ func (ctx httpBufferCtx) Reset(i interface{}) {
 }
 
 type httpBuffers struct {
-	serverStream serverStream
-	serverRequest   fasthttp.Request
+	serverStream   serverStream
+	serverRequest  fasthttp.Request
 	serverResponse fasthttp.Response
 
-	clientStream clientStream
+	clientStream   clientStream
 	clientRequest  fasthttp.Request
-	clientResponse  fasthttp.Response
+	clientResponse fasthttp.Response
 }
 
 func httpBuffersByContext(context context.Context) *httpBuffers {

--- a/pkg/stream/http/buffer.go
+++ b/pkg/stream/http/buffer.go
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package http
+
+import (
+	"github.com/alipay/sofa-mosn/pkg/buffer"
+	"context"
+	"github.com/valyala/fasthttp"
+)
+
+func init() {
+	buffer.RegisterBuffer(&ins)
+}
+
+var ins = httpBufferCtx{}
+
+type httpBufferCtx struct {
+	buffer.TempBufferCtx
+}
+
+func (ctx httpBufferCtx) New() interface{} {
+	return new(httpBuffers)
+}
+
+func (ctx httpBufferCtx) Reset(i interface{}) {
+	buf, _ := i.(*httpBuffers)
+	buf.serverStream = serverStream{}
+	buf.serverRequest.Reset()
+	buf.serverResponse.Reset()
+	buf.clientStream = clientStream{}
+	buf.clientRequest.Reset()
+	buf.clientResponse.Reset()
+}
+
+type httpBuffers struct {
+	serverStream serverStream
+	serverRequest   fasthttp.Request
+	serverResponse fasthttp.Response
+
+	clientStream clientStream
+	clientRequest  fasthttp.Request
+	clientResponse  fasthttp.Response
+}
+
+func httpBuffersByContext(context context.Context) *httpBuffers {
+	ctx := buffer.PoolContext(context)
+	return ctx.Find(&ins, nil).(*httpBuffers)
+}

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -106,7 +106,7 @@ func (f *streamConnFactory) ProtocolMatch(prot string, magic []byte) error {
 // types.StreamConnection
 // types.StreamConnectionEventListener
 type streamConnection struct {
-	context context.Context
+	context        context.Context
 
 	conn              types.Connection
 	connEventListener types.ConnectionEventListener
@@ -164,23 +164,25 @@ type clientStreamConnection struct {
 	streamConnection
 
 	stream                        *clientStream
+	requestSent                   chan bool
 	mutex                         sync.RWMutex
 	connectionEventListener       types.ConnectionEventListener
 	streamConnectionEventListener types.StreamConnectionEventListener
 }
 
-func newClientStreamConnection(context context.Context, connection types.ClientConnection,
+func newClientStreamConnection(ctx context.Context, connection types.ClientConnection,
 	streamConnCallbacks types.StreamConnectionEventListener,
 	connCallbacks types.ConnectionEventListener) types.ClientStreamConnection {
 
 	csc := &clientStreamConnection{
 		streamConnection: streamConnection{
-			context: context,
-			conn:    connection,
-			bufChan: make(chan types.IoBuffer),
+			context:        ctx,
+			conn:           connection,
+			bufChan:        make(chan types.IoBuffer),
 		},
 		connectionEventListener:       connCallbacks,
 		streamConnectionEventListener: streamConnCallbacks,
+		requestSent:                   make(chan bool, 1),
 	}
 
 	csc.br = bufio.NewReader(csc)
@@ -204,22 +206,26 @@ func newClientStreamConnection(context context.Context, connection types.ClientC
 
 func (conn *clientStreamConnection) serve() {
 	for {
-		// 1. blocking read using fasthttp.Response.Read
-		response := fasthttp.AcquireResponse()
+		if _, ok := <-conn.requestSent; !ok {
+			return
+		}
 
-		err := response.Read(conn.br)
+		s := conn.stream
+		buffers := httpBuffersByContext(s.ctx)
+		s.response = &buffers.clientResponse
+
+		// 1. blocking read using fasthttp.Response.Read
+		err := s.response.Read(conn.br)
 		if err != nil {
-			if conn.stream != nil {
-				conn.stream.ResetStream(types.StreamRemoteReset)
+			if s != nil{
+				s.ResetStream(types.StreamRemoteReset)
 				log.DefaultLogger.Errorf("Http client codec goroutine error: %s", err)
+
 			}
 			return
 		}
 
 		// 2. response processing
-		s := conn.stream
-		s.response = response
-
 		resetConn := false
 		if s.response.ConnectionClose() {
 			resetConn = true
@@ -229,7 +235,7 @@ func (conn *clientStreamConnection) serve() {
 			s.handleResponse()
 		}
 
-		// local reset
+		// 3. local reset if header 'Connection: close' exists
 		if resetConn {
 			// close connection
 			s.connection.conn.Close(types.NoFlush, types.LocalClose)
@@ -242,20 +248,19 @@ func (conn *clientStreamConnection) GoAway() {}
 
 func (conn *clientStreamConnection) NewStream(ctx context.Context, receiver types.StreamReceiveListener) types.StreamSender {
 	id := protocol.GenerateID()
-	s := &clientStream{
-		stream: stream{
-			id:       id,
-			ctx:      context.WithValue(ctx, types.ContextKeyStreamID, id),
-			request:  fasthttp.AcquireRequest(),
-			receiver: receiver,
-		},
-		connection: conn,
+	buffers := httpBuffersByContext(ctx)
+	s := &buffers.clientStream
+	s.stream = stream{
+		id:       id,
+		ctx:      context.WithValue(ctx, types.ContextKeyStreamID, id),
+		request:  &buffers.clientRequest,
+		receiver: receiver,
 	}
+	s.connection = conn
 
 	conn.mutex.Lock()
 	conn.stream = s
 	conn.mutex.Unlock()
-
 	return s
 }
 
@@ -272,27 +277,33 @@ func (conn *clientStreamConnection) ActiveStreamsNum() int {
 
 func (conn *clientStreamConnection) Reset(reason types.StreamResetReason) {
 	close(conn.bufChan)
+	close(conn.requestSent)
 }
 
 // types.ServerStreamConnection
 type serverStreamConnection struct {
 	streamConnection
+	contextManager contextManager
 
 	stream                   *serverStream
 	mutex                    sync.RWMutex
 	serverStreamConnListener types.ServerStreamConnectionEventListener
 }
 
-func newServerStreamConnection(context context.Context, connection types.Connection,
+func newServerStreamConnection(ctx context.Context, connection types.Connection,
 	callbacks types.ServerStreamConnectionEventListener) types.ServerStreamConnection {
 	ssc := &serverStreamConnection{
 		streamConnection: streamConnection{
-			context: context,
-			conn:    connection,
-			bufChan: make(chan types.IoBuffer),
+			context:        ctx,
+			conn:           connection,
+			bufChan:        make(chan types.IoBuffer),
 		},
+		contextManager: contextManager{base: ctx},
 		serverStreamConnListener: callbacks,
 	}
+
+	// init first context
+	ssc.contextManager.next()
 
 	ssc.br = bufio.NewReader(ssc)
 	ssc.bw = bufio.NewWriter(ssc)
@@ -315,8 +326,12 @@ func newServerStreamConnection(context context.Context, connection types.Connect
 
 func (conn *serverStreamConnection) serve() {
 	for {
-		// 1. blocking read using fasthttp.Request.Read
-		request := fasthttp.AcquireRequest()
+		// 1. pre alloc stream-level ctx with bufferCtx
+		ctx := conn.contextManager.curr
+		buffers := httpBuffersByContext(ctx)
+		request := &buffers.serverRequest
+
+		// 2. blocking read using fasthttp.Request.Read
 		err := request.Read(conn.br)
 		if err != nil {
 			if conn.stream != nil {
@@ -327,17 +342,16 @@ func (conn *serverStreamConnection) serve() {
 		}
 
 		id := protocol.GenerateID()
-		// 2. request processing
-		s := &serverStream{
-			stream: stream{
-				id:       id,
-				ctx:      context.WithValue(conn.context, types.ContextKeyStreamID, id),
-				request:  request,
-				response: fasthttp.AcquireResponse(),
-			},
-			connection:       conn,
-			responseDoneChan: make(chan bool, 1),
+		s := &buffers.serverStream
+		// 3. request processing
+		s.stream = stream{
+			id:       id,
+			ctx:      context.WithValue(conn.context, types.ContextKeyStreamID, id),
+			request:  request,
+			response: &buffers.serverResponse,
 		}
+		s.connection = conn
+		s.responseDoneChan = make(chan bool, 1)
 
 		s.receiver = conn.serverStreamConnListener.NewStreamDetect(s.stream.ctx, s, spanBuilder)
 
@@ -349,8 +363,9 @@ func (conn *serverStreamConnection) serve() {
 			s.handleRequest()
 		}
 
-		// wait for proxy done
+		// 4. wait for proxy done
 		<-s.responseDoneChan
+		conn.contextManager.next()
 	}
 }
 
@@ -438,6 +453,7 @@ func (s *clientStream) AppendTrailers(context context.Context, trailers types.He
 
 func (s *clientStream) endStream() {
 	s.doSend()
+	s.connection.requestSent <- true
 }
 
 func (s *clientStream) ReadDisable(disable bool) {
@@ -579,13 +595,6 @@ func (s *serverStream) endStream() {
 	s.connection.mutex.Lock()
 	s.connection.stream = nil
 	s.connection.mutex.Unlock()
-
-	if s.request != nil {
-		fasthttp.ReleaseRequest(s.request)
-	}
-	if s.response != nil {
-		fasthttp.ReleaseResponse(s.response)
-	}
 }
 
 func (s *serverStream) ReadDisable(disable bool) {
@@ -684,4 +693,15 @@ func removeInternalHeaders(headers mosnhttp.RequestHeader, remoteAddr net.Addr) 
 		headers.SetHost(host)
 	}
 
+}
+
+// contextManager
+type contextManager struct {
+	base context.Context
+	curr context.Context
+}
+
+func (cm *contextManager) next() {
+	// new context
+	cm.curr = buffer.NewBufferPoolContext(cm.base)
 }

--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -346,7 +346,7 @@ func (conn *serverStreamConnection) serve() {
 		// 3. request processing
 		s.stream = stream{
 			id:       id,
-			ctx:      context.WithValue(conn.context, types.ContextKeyStreamID, id),
+			ctx:      context.WithValue(ctx, types.ContextKeyStreamID, id),
 			request:  request,
 			response: &buffers.serverResponse,
 		}

--- a/pkg/stream/http/trace.go
+++ b/pkg/stream/http/trace.go
@@ -18,11 +18,7 @@
 package http
 
 import (
-	"time"
-
-	"github.com/alipay/sofa-mosn/pkg/trace"
 	"github.com/alipay/sofa-mosn/pkg/types"
-	"github.com/valyala/fasthttp"
 )
 
 var spanBuilder = &SpanBuilder{}
@@ -35,14 +31,12 @@ func (spanBuilder *SpanBuilder) BuildSpan(args ...interface{}) types.Span {
 		return nil
 	}
 
-	if requestCtx, ok := args[0].(fasthttp.RequestCtx); ok {
-		span := trace.Tracer().Start(time.Now())
-		span.SetTag(trace.PROTOCOL, "http")
-		span.SetTag(trace.METHOD_NAME, string(requestCtx.Method()))
-		span.SetTag(trace.REQUEST_URL, string(requestCtx.Host())+string(requestCtx.Path()))
-		span.SetTag(trace.REQUEST_SIZE, "0") // TODO
-		return span
-	}
+	//if ctx, ok := args[0].(context.Context); ok {
+	//	buffers := httpBuffersByContext(ctx)
+	//	requset := &buffers.serverRequest
+	//
+	//  TODO ...
+	//}
 
 	return nil
 }


### PR DESCRIPTION
### Solutions

使用MOSN自身的内存复用框架替换fasthttp自身的pool，统一复用内存的回收时机

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
