### PR TITLE
optimize router handler

### DIFF
--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -70,8 +70,10 @@ type simpleHandler struct {
 	route types.Route
 }
 
-func (h *simpleHandler) IsAvailable(ctx context.Context, snapshot types.ClusterSnapshot) types.HandlerStatus {
-	return types.HandlerAvailable
+func (h *simpleHandler) IsAvailable(ctx context.Context, f func(context.Context, string) types.ClusterSnapshot) (types.ClusterSnapshot, types.HandlerStatus) {
+	clusterName := h.Route().RouteRule().ClusterName()
+	snapshot := f(context.Background(), clusterName)
+	return snapshot, types.HandlerAvailable
 }
 
 func (h *simpleHandler) Route() types.Route {

--- a/pkg/router/factory.go
+++ b/pkg/router/factory.go
@@ -71,6 +71,9 @@ type simpleHandler struct {
 }
 
 func (h *simpleHandler) IsAvailable(ctx context.Context, f func(context.Context, string) types.ClusterSnapshot) (types.ClusterSnapshot, types.HandlerStatus) {
+	if h.route == nil {
+		return nil, types.HandlerNotAvailable
+	}
 	clusterName := h.Route().RouteRule().ClusterName()
 	snapshot := f(context.Background(), clusterName)
 	return snapshot, types.HandlerAvailable

--- a/pkg/router/handlerchain.go
+++ b/pkg/router/handlerchain.go
@@ -49,9 +49,10 @@ func (hc *RouteHandlerChain) DoNextHandler() (types.ClusterSnapshot, types.Route
 	if handler.Route() == nil {
 		return hc.DoNextHandler()
 	}
-	clusterName := handler.Route().RouteRule().ClusterName()
-	snapshot := hc.clusterManager.GetClusterSnapshot(context.Background(), clusterName)
-	status := handler.IsAvailable(hc.ctx, snapshot)
+	//clusterName := handler.Route().RouteRule().ClusterName()
+	//snapshot := hc.clusterManager.GetClusterSnapshot(context.Background(), clusterName)
+	//status := handler.IsAvailable(hc.ctx, snapshot)
+	snapshot, status := handler.IsAvailable(hc.ctx, hc.clusterManager.GetClusterSnapshot)
 	switch status {
 	case types.HandlerAvailable:
 		return snapshot, handler.Route()

--- a/pkg/router/handlerchain.go
+++ b/pkg/router/handlerchain.go
@@ -46,12 +46,6 @@ func (hc *RouteHandlerChain) DoNextHandler() (types.ClusterSnapshot, types.Route
 	if handler == nil {
 		return nil, nil
 	}
-	if handler.Route() == nil {
-		return hc.DoNextHandler()
-	}
-	//clusterName := handler.Route().RouteRule().ClusterName()
-	//snapshot := hc.clusterManager.GetClusterSnapshot(context.Background(), clusterName)
-	//status := handler.IsAvailable(hc.ctx, snapshot)
 	snapshot, status := handler.IsAvailable(hc.ctx, hc.clusterManager.GetClusterSnapshot)
 	switch status {
 	case types.HandlerAvailable:

--- a/pkg/router/handlerchain_test.go
+++ b/pkg/router/handlerchain_test.go
@@ -116,8 +116,10 @@ type mockStatusHandler struct {
 	router types.Route
 }
 
-func (h *mockStatusHandler) IsAvailable(ctx context.Context, snapshot types.ClusterSnapshot) types.HandlerStatus {
-	return h.status
+func (h *mockStatusHandler) IsAvailable(ctx context.Context, f func(context.Context, string) types.ClusterSnapshot) (types.ClusterSnapshot, types.HandlerStatus) {
+	clusterName := h.Route().RouteRule().ClusterName()
+	snapshot := f(context.Background(), clusterName)
+	return snapshot, h.status
 }
 func (h *mockStatusHandler) Route() types.Route {
 	return h.router

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -68,7 +68,7 @@ const (
 // RouteHandler is an external check handler for a route
 type RouteHandler interface {
 	// IsAvailable returns HandlerStatus represents the handler will be used/not used/stop next handler check
-	IsAvailable(context.Context, ClusterSnapshot) HandlerStatus
+	IsAvailable(context.Context, func(context.Context, string) ClusterSnapshot) (ClusterSnapshot, HandlerStatus)
 	// Route returns handler's route
 	Route() Route
 }


### PR DESCRIPTION
在某些需求场景下，Handler获取ClusterSnapshot的需求希望更加灵活，但是ClusterSnapshot的管理又希望由HandlerChain来统一负责。
修改Handler的IsVailable接口，将获取ClusterSnapshot的函数作为参数传入，而不是直接传入ClusterSnapshot来解决这个问题。