### PR TITLE
support listener's tls update, optimize listener update

### DIFF
--- a/cmd/mosn/main/control.go
+++ b/cmd/mosn/main/control.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
 	"github.com/alipay/sofa-mosn/pkg/config"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/mosn"
@@ -55,9 +54,6 @@ var (
 			serviceCluster := c.String("service-cluster")
 			serviceNode := c.String("service-node")
 			conf := config.Load(configPath)
-			// start admin server
-			adminServer := admin.Server{}
-			adminServer.Start(conf)
 			// start pprof
 			if conf.Debug.StartDebug {
 				port := 9090 //default use 9090

--- a/pkg/admin/server/apis.go
+++ b/pkg/admin/server/apis.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 
 	"github.com/alipay/sofa-mosn/pkg/admin/store"
-	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/metrics"
 	"github.com/alipay/sofa-mosn/pkg/metrics/sink/console"
-	"github.com/alipay/sofa-mosn/pkg/server"
 	"github.com/valyala/fasthttp"
 )
 
@@ -70,38 +68,4 @@ func setLogLevel(ctx *fasthttp.RequestCtx) {
 		msg := fmt.Sprintf(errMsgFmt, "unknown log level")
 		ctx.WriteString(msg)
 	}
-}
-
-// POST Data Format
-/*
-{
-	"listener": "string",
-	"inspector": bool,
-	"tls_context": {}
-}
-*/
-type tlsUpdate struct {
-	Listener  string       `json:"listener"`
-	Inspetcor bool         `json:"inspetcor"`
-	TLSConfig v2.TLSConfig `json:"tls_context"`
-}
-
-func updateListenerTLS(ctx *fasthttp.RequestCtx) {
-	body := ctx.Request.Body()
-	data := &tlsUpdate{}
-	if err := json.Unmarshal(body, data); err != nil {
-		ctx.SetStatusCode(400)
-		ctx.Write([]byte(`{ error: "invalid post data"}`))
-		return
-	}
-	adapter := server.GetListenerAdapterInstance()
-	// server can be "", so use the default server. currently we only support one server, so use "" is ok
-	if err := adapter.UpdateListenerTLS("", data.Listener, data.Inspetcor, &data.TLSConfig); err != nil {
-		ctx.SetStatusCode(500)
-		msg := ""
-		ctx.Write([]byte(msg))
-		return
-	}
-	log.DefaultLogger.Infof("listener %s's tls config has been changed, inspector: %v, tlsstart: %v", data.Listener, data.Inspetcor, data.TLSConfig.Status)
-	ctx.WriteString("update tls success\n")
 }

--- a/pkg/admin/server/apis.go
+++ b/pkg/admin/server/apis.go
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"fmt"
+
+	"github.com/alipay/sofa-mosn/pkg/admin/store"
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	"github.com/alipay/sofa-mosn/pkg/log"
+	"github.com/alipay/sofa-mosn/pkg/metrics"
+	"github.com/alipay/sofa-mosn/pkg/metrics/sink/console"
+	"github.com/alipay/sofa-mosn/pkg/server"
+	"github.com/valyala/fasthttp"
+)
+
+var levelMap = map[string]log.Level{
+	"FATAL": log.FATAL,
+	"ERROR": log.ERROR,
+	"WARN":  log.WARN,
+	"INFO":  log.INFO,
+	"DEBUG": log.DEBUG,
+	"TRACE": log.TRACE,
+}
+
+const errMsgFmt = `{
+	"error": "%s"
+}
+`
+
+func configDump(ctx *fasthttp.RequestCtx) {
+	if buf, err := store.Dump(); err == nil {
+		ctx.Write(buf)
+	} else {
+		ctx.SetStatusCode(500)
+		msg := fmt.Sprintf(errMsgFmt, "internal error")
+		ctx.WriteString(msg)
+		log.DefaultLogger.Errorf("Admin API: ConfigDump failed, cause by %s", err)
+	}
+}
+
+func statsDump(ctx *fasthttp.RequestCtx) {
+	sink := console.NewConsoleSink(ctx.Response.BodyWriter())
+	sink.Flush(metrics.GetAll())
+}
+
+func setLogLevel(ctx *fasthttp.RequestCtx) {
+	body := string(ctx.Request.Body())
+	if level, ok := levelMap[body]; ok {
+		log.DefaultLogger.Level = level
+		log.DefaultLogger.Infof("DefaultLogger level has been changed to %s", body)
+		ctx.WriteString("update logger success\n")
+	} else {
+		ctx.SetStatusCode(500)
+		msg := fmt.Sprintf(errMsgFmt, "unknown log level")
+		ctx.WriteString(msg)
+	}
+}
+
+// POST Data Format
+/*
+{
+	"listener": "string",
+	"inspector": bool,
+	"tls_context": {}
+}
+*/
+type tlsUpdate struct {
+	Listener  string       `json:"listener"`
+	Inspetcor bool         `json:"inspetcor"`
+	TLSConfig v2.TLSConfig `json:"tls_context"`
+}
+
+func updateListenerTLS(ctx *fasthttp.RequestCtx) {
+	body := ctx.Request.Body()
+	data := &tlsUpdate{}
+	if err := json.Unmarshal(body, data); err != nil {
+		ctx.SetStatusCode(400)
+		ctx.Write([]byte(`{ error: "invalid post data"}`))
+		return
+	}
+	adapter := server.GetListenerAdapterInstance()
+	// server can be "", so use the default server. currently we only support one server, so use "" is ok
+	if err := adapter.UpdateListenerTLS("", data.Listener, data.Inspetcor, &data.TLSConfig); err != nil {
+		ctx.SetStatusCode(500)
+		msg := ""
+		ctx.Write([]byte(msg))
+		return
+	}
+	log.DefaultLogger.Infof("listener %s's tls config has been changed, inspector: %v, tlsstart: %v", data.Listener, data.Inspetcor, data.TLSConfig.Status)
+	ctx.WriteString("update tls success\n")
+}

--- a/pkg/admin/server/server.go
+++ b/pkg/admin/server/server.go
@@ -65,8 +65,6 @@ func postAPIs(ctx *fasthttp.RequestCtx) {
 	switch path {
 	case "/api/v1/logging":
 		setLogLevel(ctx)
-	case "/api/v1/tls":
-		updateListenerTLS(ctx)
 	default:
 		ctx.SetStatusCode(404)
 	}

--- a/pkg/admin/server/server.go
+++ b/pkg/admin/server/server.go
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-package admin
+package server
 
 import (
 	"fmt"
 	"net"
+	"net/http"
 
+	"github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/log"
-	"github.com/alipay/sofa-mosn/pkg/metrics"
-	"github.com/alipay/sofa-mosn/pkg/metrics/sink/console"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/json-iterator/go"
 	"github.com/valyala/fasthttp"
@@ -35,52 +35,38 @@ type Server struct {
 	ln net.Listener
 }
 
-func configDump(ctx *fasthttp.RequestCtx) {
-	if buf, err := Dump(); err == nil {
-		ctx.Write(buf)
-	} else {
-		ctx.SetStatusCode(500)
-		ctx.Write([]byte(`{ error: "internal error" }`))
-		log.DefaultLogger.Errorf("Admin API: ConfigDump failed, cause by %s", err)
-	}
-}
-
-func statsDump(ctx *fasthttp.RequestCtx) {
-	sink := console.NewConsoleSink(ctx.Response.BodyWriter())
-	sink.Flush(metrics.GetAll())
-}
-
-var levelMap = map[string]log.Level{
-	"FATAL": log.FATAL,
-	"ERROR": log.ERROR,
-	"WARN":  log.WARN,
-	"INFO":  log.INFO,
-	"DEBUG": log.DEBUG,
-	"TRACE": log.TRACE,
-}
-
-func setLogLevel(ctx *fasthttp.RequestCtx) {
-	body := string(ctx.Request.Body())
-	if level, ok := levelMap[body]; ok {
-		log.DefaultLogger.Level = level
-		log.DefaultLogger.Infof("DefaultLogger level has been changed to %s", body)
-	} else {
-		ctx.SetStatusCode(500)
-		ctx.Write([]byte(`{ error: "unknown log level" }`))
-	}
-}
-
 func requestHandler(ctx *fasthttp.RequestCtx) {
-	path := string(ctx.Path())
 	method := string(ctx.Method())
 
-	switch {
-	case path == "/api/v1/config_dump" && method == "GET":
+	switch method {
+	case http.MethodGet:
+		getAPIs(ctx)
+	case http.MethodPost:
+		postAPIs(ctx)
+	default:
+		ctx.SetStatusCode(http.StatusMethodNotAllowed)
+	}
+}
+
+func getAPIs(ctx *fasthttp.RequestCtx) {
+	path := string(ctx.Path())
+	switch path {
+	case "/api/v1/config_dump":
 		configDump(ctx)
-	case path == "/api/v1/stats" && method == "GET":
+
+	case "/api/v1/stats":
 		statsDump(ctx)
-	case path == "/api/v1/logging" && method == "POST":
+	default:
+		ctx.SetStatusCode(404)
+	}
+}
+func postAPIs(ctx *fasthttp.RequestCtx) {
+	path := string(ctx.Path())
+	switch path {
+	case "/api/v1/logging":
 		setLogLevel(ctx)
+	case "/api/v1/tls":
+		updateListenerTLS(ctx)
 	default:
 		ctx.SetStatusCode(404)
 	}
@@ -90,7 +76,7 @@ func (s *Server) Start(config Config) {
 	var addr string
 	if config != nil {
 		// merge MOSNConfig into global context
-		SetMOSNConfig(config)
+		store.SetMOSNConfig(config)
 		// get admin config
 		adminConfig := config.GetAdmin()
 		if adminConfig == nil {
@@ -117,7 +103,7 @@ func (s *Server) Start(config Config) {
 	log.DefaultLogger.Infof("Admin server serve on %s\n", addr)
 	s.ln = ln
 	go func() {
-		AddStoppable(s)
+		store.AddStoppable(s)
 		if err := srv.Serve(ln); err != nil {
 			log.DefaultLogger.Errorf("Admin server: Served) with error: %s\n", err)
 		}

--- a/pkg/admin/server/server_test.go
+++ b/pkg/admin/server/server_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package admin
+package server
 
 import (
 	"errors"
@@ -26,6 +26,7 @@ import (
 
 	rawjson "encoding/json"
 
+	"github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/metrics"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
@@ -106,7 +107,7 @@ func TestDumpConfig(t *testing.T) {
 			t.Errorf("unexpected effectiveConfig: %s\n", data)
 		}
 	}
-	Reset()
+	store.Reset()
 }
 
 func TestDumpStats(t *testing.T) {
@@ -138,5 +139,7 @@ func TestDumpStats(t *testing.T) {
 			t.Errorf("unexpected stats: %s\n", data)
 		}
 	}
-	Reset()
+	store.Reset()
 }
+
+// TestUpdateTLS see integrate test

--- a/pkg/admin/server/types.go
+++ b/pkg/admin/server/types.go
@@ -1,4 +1,4 @@
-package admin
+package server
 
 import (
 	. "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"

--- a/pkg/admin/store/effectiveconfig.go
+++ b/pkg/admin/store/effectiveconfig.go
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-package admin
+package store
 
 import (
+	"encoding/json"
 	"sync"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"

--- a/pkg/admin/store/effectiveconfig_test.go
+++ b/pkg/admin/store/effectiveconfig_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package admin
+package store
 
 import (
 	"errors"

--- a/pkg/admin/store/stoppbale.go
+++ b/pkg/admin/store/stoppbale.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package admin
+package store
 
 import (
 	"github.com/alipay/sofa-mosn/pkg/log"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,7 +127,7 @@ var (
 func (c *MOSNConfig) GetAdmin() *xdsboot.Admin {
 	if len(c.RawAdmin) > 0 {
 		adminConfig := &xdsboot.Admin{}
-		err := jsonpb.UnmarshalString(string(config.RawAdmin), adminConfig)
+		err := jsonpb.UnmarshalString(string(c.RawAdmin), adminConfig)
 		if err == nil {
 			return adminConfig
 		}

--- a/pkg/config/dumper.go
+++ b/pkg/config/dumper.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/log"
 )
 

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -346,7 +346,7 @@ func (s *downStream) doReceiveHeaders(filter *activeStreamReceiverFilter, header
 		s.sendHijackReply(types.RouterUnavailableCode, headers)
 		return
 	}
-	if reflect.ValueOf(clusterSnapshot).IsNil() {
+	if clusterSnapshot == nil || reflect.ValueOf(clusterSnapshot).IsNil() {
 		// no available cluster
 		log.DefaultLogger.Errorf("cluster snapshot is nil, cluster name is: %s", route.RouteRule().ClusterName())
 		s.requestInfo.SetResponseFlag(types.NoRouteFound)
@@ -547,7 +547,7 @@ func (s *downStream) setupPerReqTimeout() {
 			s.perRetryTimer.Stop()
 		}
 
-		s.perRetryTimer = utils.NewTimer(timeout.TryTimeout * time.Second, s.onPerReqTimeout)
+		s.perRetryTimer = utils.NewTimer(timeout.TryTimeout*time.Second, s.onPerReqTimeout)
 	}
 }
 

--- a/pkg/router/routersmanager.go
+++ b/pkg/router/routersmanager.go
@@ -26,7 +26,7 @@ import (
 
 	"fmt"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/types"

--- a/pkg/server/adapter.go
+++ b/pkg/server/adapter.go
@@ -57,6 +57,12 @@ func GetListenerAdapterInstance() *ListenerAdapter {
 	return listenerAdapterInstance
 }
 
+// ResetAdapter only used in test/debug mode
+func ResetAdapter() {
+	log.DefaultLogger.Infof("adapter reset, only expected in test/debug mode")
+	listenerAdapterInstance = nil
+}
+
 // AddOrUpdateListener used to:
 // Add and start listener when listener doesn't exist
 // Update listener when listener already exist

--- a/pkg/server/adapter.go
+++ b/pkg/server/adapter.go
@@ -30,15 +30,23 @@ var listenerAdapterInstance *ListenerAdapter
 type ListenerAdapter struct {
 	connHandlerMap     map[string]types.ConnectionHandler // key is server's name
 	defaultConnHandler types.ConnectionHandler
+	defaultName        string
 }
 
 // todo consider to use singleton
 func initListenerAdapterInstance(name string, connHandler types.ConnectionHandler) {
 	if listenerAdapterInstance == nil {
 		listenerAdapterInstance = &ListenerAdapter{
-			connHandlerMap:     make(map[string]types.ConnectionHandler),
-			defaultConnHandler: connHandler, // in this case, the first server's connHandler will be the default connHandler
+			connHandlerMap: make(map[string]types.ConnectionHandler),
+			// we set the first handler as the default handler
+			// the handler name should be keeped, so if the handler changed, the default handler changed too.
+			defaultName: name,
 		}
+	}
+
+	// if the handler's name is same as default, the default handler changed too
+	if name == listenerAdapterInstance.defaultName {
+		listenerAdapterInstance.defaultConnHandler = connHandler
 	}
 
 	listenerAdapterInstance.connHandlerMap[name] = connHandler
@@ -114,4 +122,35 @@ func (adapter *ListenerAdapter) DeleteListener(serverName string, listenerName s
 	// then remove it from array
 	connHandler.RemoveListeners(listenerName)
 	return nil
+}
+
+func (adapter *ListenerAdapter) UpdateListenerTLS(serverName string, listenerName string, inspector bool, tls *v2.TLSConfig) error {
+	var connHandler types.ConnectionHandler
+	if serverName == "" {
+		connHandler = adapter.defaultConnHandler
+	} else {
+		if ch, ok := adapter.connHandlerMap[serverName]; ok {
+			connHandler = ch
+		} else {
+			return fmt.Errorf("AddOrUpdateListener error, servername = %s not found", serverName)
+		}
+	}
+
+	if ln := connHandler.FindListenerByName(listenerName); ln != nil {
+		cfg := *ln.Config() // should clone a config
+		cfg.Inspector = inspector
+		cfg.FilterChains = []v2.FilterChain{
+			{
+				FilterChainMatch: cfg.FilterChains[0].FilterChainMatch,
+				Filters:          cfg.FilterChains[0].Filters,
+				TLS:              *tls,
+			},
+		}
+		if _, err := connHandler.AddOrUpdateListener(&cfg, nil, nil); err != nil {
+			return fmt.Errorf("connHandler.UpdateListenerTLS called error, server:%s, error: %s", serverName, err.Error())
+		}
+		return nil
+	}
+	return fmt.Errorf("listener %s is not found", listenerName)
+
 }

--- a/pkg/server/adapter_test.go
+++ b/pkg/server/adapter_test.go
@@ -1,276 +1,229 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package server
 
 import (
-	"fmt"
+	"crypto/tls"
 	"net"
-	"sync"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/types"
-	"github.com/alipay/sofa-mosn/pkg/upstream/cluster"
 )
 
-type clusterManagerFilterMocK struct {
-	cccb types.ClusterConfigFactoryCb
-	chcb types.ClusterHostFactoryCb
+const testServerName = "test_server"
+
+func setup() {
+	handler := NewHandler(&mockClusterManagerFilter{}, &mockClusterManager{}, log.DefaultLogger)
+	initListenerAdapterInstance(testServerName, handler)
 }
 
-func (cmf *clusterManagerFilterMocK) OnCreated(cccb types.ClusterConfigFactoryCb, chcb types.ClusterHostFactoryCb) {
-	cmf.cccb = cccb
-	cmf.chcb = chcb
+func TestMain(m *testing.M) {
+	setup()
+	m.Run()
 }
 
-var srvAddresses = []string{"127.0.0.1:8080", "127.0.0.1:8081", "127.0.0.1:8082"}
-var clnAddresses = []string{"127.0.0.1:9090", "127.0.0.1:9091", "127.0.0.1:9092"}
-
-var once sync.Once
-var stopServerChan = make(chan bool, 1)
-
-func runMockServer(t *testing.T) {
-	once.Do(func() {
-
-		address, err := net.ResolveTCPAddr("tcp", srvAddresses[0])
-		if err != nil {
-			t.Errorf("resolve tcp address error, address = %s", address)
-		}
-
-		mockConfig := &Config{
-			ServerName: "mock_server_1",
-			LogPath:    "",
-			LogLevel:   log.DEBUG,
-		}
-
-		log.InitDefaultLogger(mockConfig.LogPath, mockConfig.LogLevel)
-
-		cmf := &clusterManagerFilterMocK{}
-		cm := cluster.NewClusterManager(nil, nil, nil, true, false)
-		mockServer := NewServer(mockConfig, cmf, cm)
-
-		listenConfig := &v2.Listener{
-			ListenerConfig: v2.ListenerConfig{
-				Name:       "listener1",
-				BindToPort: true,
-				LogPath:    "stdout",
-				HandOffRestoredDestinationConnections: true,
-			},
-			Addr: address,
-			PerConnBufferLimitBytes: 1 << 15,
-			LogLevel:                3,
-		}
-
-		mockServer.AddListener(listenConfig, nil, nil)
-		mockServer.Start()
-
-		for {
-			select {
-			case <-stopServerChan:
-				mockServer.Close()
-			}
-		}
-	})
-}
-
-func runMockClientConnect(clientAddress string, serverAddress string) (net.Conn, error) {
-	localTCPAddr, err1 := net.ResolveTCPAddr("tcp", clientAddress)
-	if err1 != nil {
-		return nil, fmt.Errorf("resolve tcp address error, clientaddress = %s", clientAddress)
-	}
-
-	remoteTCPAddr, err2 := net.ResolveTCPAddr("tcp", serverAddress)
-
-	if err2 != nil {
-		return nil, fmt.Errorf("resolve tcp address error, clientaddress = %s, server", serverAddress)
-	}
-
-	conn, err := net.DialTCP("tcp", localTCPAddr, remoteTCPAddr)
-	return conn, err
-}
-
-func TestListenerAdapter_AddOrUpdateListener(t *testing.T) {
-	go runMockServer(t)
-	time.Sleep(1 * time.Second) // wait server start
-
-	serverAddress := srvAddresses[1]
-	localTCPAddr := clnAddresses[0]
-	addedAddress, _ := net.ResolveTCPAddr("tcp", serverAddress) //added server
-
-	addedListenerConfig := &v2.Listener{
+func baseListenerConfig(addrStr string, name string) *v2.Listener {
+	// add a new listener
+	addr, _ := net.ResolveTCPAddr("tcp", addrStr)
+	return &v2.Listener{
 		ListenerConfig: v2.ListenerConfig{
-			Name:       "listener2",
-			BindToPort: true,
-			LogPath:    "stdout",
-			HandOffRestoredDestinationConnections: true,
+			Name:           name,
+			BindToPort:     true,
+			LogPath:        "stdout",
+			LogLevelConfig: "DEBUG",
+			AccessLogs: []v2.AccessLog{
+				{
+					Path:   "stdout",
+					Format: types.DefaultAccessLogFormat,
+				},
+			},
+			FilterChains: []v2.FilterChain{
+				{
+					TLS: v2.TLSConfig{
+						Status:     true,
+						CACert:     mockCAPEM,
+						CertChain:  mockCertPEM,
+						PrivateKey: mockKeyPEM,
+					},
+					Filters: []v2.Filter{
+						{
+							Type: "network",
+							Config: map[string]interface{}{
+								"network": "exists",
+							},
+						}, // no network filter parsed, but the config still exists for test
+					},
+				},
+			},
+			StreamFilters: []v2.Filter{
+				{
+					Type: "stream",
+					Config: map[string]interface{}{
+						"stream": "exists",
+					},
+				},
+			}, //no stream filters parsed, but the config still exists for test
 		},
-		Addr: addedAddress,
+		Addr: addr,
 		PerConnBufferLimitBytes: 1 << 15,
-		LogLevel:                3,
-	}
-
-	updateListenerConfig := &v2.Listener{
-		ListenerConfig: v2.ListenerConfig{
-			Name:       "listener2",
-			BindToPort: false,
-			LogPath:    "stdout",
-			HandOffRestoredDestinationConnections: true,
-		},
-		Addr: addedAddress,
-		PerConnBufferLimitBytes: 1 << 15,
-		LogLevel:                3,
-	}
-
-	type fields struct {
-		connHandlerMap     map[string]types.ConnectionHandler
-		defaultConnHandler types.ConnectionHandler
-	}
-	type args struct {
-		serverName             string
-		lc                     *v2.Listener
-		networkFiltersFactory  []types.NetworkFilterChainFactory
-		streamFiltersFactories []types.StreamFilterChainFactory
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "testListenerAdd",
-			fields: fields{
-				connHandlerMap:     GetListenerAdapterInstance().connHandlerMap,
-				defaultConnHandler: GetListenerAdapterInstance().defaultConnHandler,
-			},
-			args: args{
-				serverName: "",
-				lc:         addedListenerConfig,
-				networkFiltersFactory:  nil,
-				streamFiltersFactories: nil,
-			},
-			wantErr: false,
-		},
-		{
-			name: "testListenerUpdate",
-			fields: fields{
-				connHandlerMap:     GetListenerAdapterInstance().connHandlerMap,
-				defaultConnHandler: GetListenerAdapterInstance().defaultConnHandler,
-			},
-			args: args{
-				serverName: "",
-				lc:         updateListenerConfig,
-				networkFiltersFactory:  nil,
-				streamFiltersFactories: nil,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			adapter := &ListenerAdapter{
-				connHandlerMap:     tt.fields.connHandlerMap,
-				defaultConnHandler: tt.fields.defaultConnHandler,
-			}
-
-			if tt.name == "testListenerAdd" {
-				// expect connect failure
-				if adapter.defaultConnHandler.FindListenerByName("listener2") != nil {
-					t.Errorf("listener = %s already in", srvAddresses[0])
-				}
-
-				if conn, err := runMockClientConnect(localTCPAddr, srvAddresses[1]); err == nil {
-					t.Errorf("listener = %s already running, need check ", srvAddresses[1])
-					conn.Close()
-				}
-
-				// do listener start
-				if err := adapter.AddOrUpdateListener(tt.args.serverName, tt.args.lc, tt.args.networkFiltersFactory, tt.args.streamFiltersFactories); (err != nil) != tt.wantErr {
-					t.Errorf("ListenerAdapter.AddOrUpdateListener() error = %v, wantErr %v", err, tt.wantErr)
-				}
-
-				time.Sleep(1 * time.Second) // wait listener start
-
-				// expect connect success
-				if adapter.defaultConnHandler.FindListenerByName("listener2") == nil {
-					t.Errorf("listener = %s add listener error", srvAddresses[0])
-				}
-
-				if conn, err := runMockClientConnect(localTCPAddr, srvAddresses[1]); err != nil {
-					t.Errorf("ListenerAdapter.AddOrUpdateListener() error = %v, wantErr %v", err, tt.wantErr)
-
-				} else {
-					conn.Close()
-				}
-			}
-
-			if tt.name == "testListenerUpdate" {
-				if err := adapter.AddOrUpdateListener(tt.args.serverName, tt.args.lc, tt.args.networkFiltersFactory, tt.args.streamFiltersFactories); (err != nil) != tt.wantErr {
-					t.Errorf("ListenerAdapter.AddOrUpdateListener() error = %v, wantErr %v", err, tt.wantErr)
-				}
-
-				if listener := adapter.defaultConnHandler.FindListenerByName("listener2"); listener == nil {
-					t.Errorf("testListenerUpdate error, listener don't exist")
-				} else if listener.Config() != updateListenerConfig {
-					t.Errorf("testListenerUpdate error, config remain the same")
-				}
-			}
-		})
+		LogLevel:                uint8(log.DEBUG),
 	}
 }
 
-func TestListenerAdapter_DeleteListener(t *testing.T) {
-	go runMockServer(t)
-	time.Sleep(1 * time.Second) // wait server start
-
-	adapter := &ListenerAdapter{
-		connHandlerMap:     GetListenerAdapterInstance().connHandlerMap,
-		defaultConnHandler: GetListenerAdapterInstance().defaultConnHandler,
+// LDS include add\update\delete listener
+func TestLDS(t *testing.T) {
+	addrStr := "127.0.0.1:8080"
+	name := "listener1"
+	listenerConfig := baseListenerConfig(addrStr, name)
+	// set a network filter do nothing, just for keep the connection not close
+	nfcfs := []types.NetworkFilterChainFactory{
+		&mockNetworkFilterFactory{},
 	}
-
-	// expect connect success
-	if adapter.defaultConnHandler.FindListenerByName("listener1") == nil {
-		t.Errorf("listener = %s doesn't start ", srvAddresses[0])
+	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, listenerConfig, nfcfs, nil); err != nil {
+		t.Fatalf("add a new listener failed", err)
 	}
-
-	if conn, err := runMockClientConnect(clnAddresses[1], srvAddresses[0]); err != nil {
-		t.Errorf("ListenerAdapter.DeleteListener() error = %s ", err.Error())
+	time.Sleep(time.Second) // wait listener start
+	// verify
+	// add listener success
+	handler := listenerAdapterInstance.defaultConnHandler.(*connHandler)
+	if len(handler.listeners) != 1 {
+		t.Fatalf("listener numbers is not expected %d", len(handler.listeners))
+	}
+	ln := handler.FindListenerByName(name)
+	if ln == nil {
+		t.Fatal("no listener found")
+	}
+	// use real connection to test
+	// tls handshake success
+	dialer := &net.Dialer{
+		Timeout: time.Second,
+	}
+	if conn, err := tls.DialWithDialer(dialer, "tcp", addrStr, &tls.Config{
+		InsecureSkipVerify: true,
+	}); err != nil {
+		t.Fatal("dial tls failed", err)
 	} else {
 		conn.Close()
 	}
-
-	// delete the listener
-	if err := adapter.DeleteListener("", "listener1"); err != nil {
-		t.Errorf("ListenerAdapter.DeleteListener() error = %v", err.Error())
+	// update listener
+	// FIXME: update logger
+	newListenerConfig := &v2.Listener{
+		ListenerConfig: v2.ListenerConfig{
+			Name:           name, // name should same as the exists listener
+			LogPath:        "stdout",
+			LogLevelConfig: "INFO", // FIXME: should be updated
+			AccessLogs: []v2.AccessLog{
+				{},
+			},
+			FilterChains: []v2.FilterChain{
+				{
+					TLS: v2.TLSConfig{ // only tls will be updated
+						Status: false,
+					},
+					Filters: []v2.Filter{}, // network filter will not be updated
+				},
+			},
+			StreamFilters: []v2.Filter{}, // stream filter will not be updated
+			Inspector:     true,
+		},
+		Addr: listenerConfig.Addr, // addr should not be changed
+		PerConnBufferLimitBytes: 1 << 10,
+		LogLevel:                uint8(log.INFO),
 	}
-
-	if adapter.defaultConnHandler.FindListenerByName("listener1") != nil {
-		t.Errorf("listener = %s doesn't stop ", srvAddresses[0])
+	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, newListenerConfig, nil, nil); err != nil {
+		t.Fatal("update listener failed", err)
 	}
+	// verify
+	// 1. listener have only 1
+	if len(handler.listeners) != 1 {
+		t.Fatalf("listener numbers is not expected %d", len(handler.listeners))
+	}
+	// 2. verify config, the updated configs should be changed, and the others should be same as old config
+	newLn := handler.FindListenerByName(name)
+	cfg := newLn.Config()
+	if !(reflect.DeepEqual(cfg.FilterChains[0].TLS, newListenerConfig.FilterChains[0].TLS) && //tls is new
+		cfg.PerConnBufferLimitBytes == 1<<10 && // PerConnBufferLimitBytes is new
+		cfg.Inspector && // inspector is new
+		reflect.DeepEqual(cfg.FilterChains[0].Filters, listenerConfig.FilterChains[0].Filters) && // network filter is old
+		reflect.DeepEqual(cfg.StreamFilters, listenerConfig.StreamFilters)) { // stream filter is old
+		// FIXME: log config is new
+		t.Fatal("new config is not expected")
+	}
+	// FIXME:
+	// Logger level is new
 
-	time.Sleep(3 * time.Second)
-
-	// expect connect failure
-	if conn, err := runMockClientConnect(clnAddresses[2], srvAddresses[0]); err == nil {
-		t.Errorf("listener = %s doesn't stop ", srvAddresses[0])
+	// 3. tls handshake should be failed, because tls is changed to false
+	if conn, err := tls.DialWithDialer(dialer, "tcp", addrStr, &tls.Config{
+		InsecureSkipVerify: true,
+	}); err == nil {
 		conn.Close()
+		t.Fatal("listener should not be support tls any more")
+	}
+	// 4.common connection should be success, network filter will not be changed
+	if conn, err := net.DialTimeout("tcp", addrStr, time.Second); err != nil {
+		t.Fatal("dial listener failed", err)
+	} else {
+		conn.Close()
+	}
+	// test delete listener
+	if err := GetListenerAdapterInstance().DeleteListener(testServerName, name); err != nil {
+		t.Fatal("delete listener failed", err)
+	}
+	time.Sleep(time.Second) // wait listener close
+	if len(handler.listeners) != 0 {
+		t.Fatal("handler still have listener")
+	}
+	// dial should be failed
+	if conn, err := net.DialTimeout("tcp", addrStr, time.Second); err == nil {
+		conn.Close()
+		t.Fatal("listener closed, dial should be failed")
+	}
+}
+
+func TestUpdateTLS(t *testing.T) {
+	addrStr := "127.0.0.1:8081"
+	name := "listener2"
+	listenerConfig := baseListenerConfig(addrStr, name)
+	// set a network filter do nothing, just for keep the connection not close
+	nfcfs := []types.NetworkFilterChainFactory{
+		&mockNetworkFilterFactory{},
+	}
+	if err := GetListenerAdapterInstance().AddOrUpdateListener(testServerName, listenerConfig, nfcfs, nil); err != nil {
+		t.Fatalf("add a new listener failed", err)
+	}
+	time.Sleep(time.Second) // wait listener start
+	tlsCfg := v2.TLSConfig{
+		Status: false,
+	}
+	// tls handleshake success
+	dialer := &net.Dialer{
+		Timeout: time.Second,
+	}
+	if conn, err := tls.DialWithDialer(dialer, "tcp", addrStr, &tls.Config{
+		InsecureSkipVerify: true,
+	}); err != nil {
+		t.Fatal("dial tls failed", err)
+	} else {
+		conn.Close()
+	}
+	if err := GetListenerAdapterInstance().UpdateListenerTLS(testServerName, name, false, &tlsCfg); err != nil {
+		t.Fatalf("update tls listener failed", err)
+	}
+	handler := listenerAdapterInstance.defaultConnHandler.(*connHandler)
+	newLn := handler.FindListenerByName(name)
+	cfg := newLn.Config()
+	// verify tls changed
+	if !(reflect.DeepEqual(cfg.FilterChains[0].TLS, tlsCfg) &&
+		cfg.Inspector == false) {
+		t.Fatal("update tls config not expected")
+	}
+	// tls handshake should be failed, because tls is changed to false
+	if conn, err := tls.DialWithDialer(dialer, "tcp", addrStr, &tls.Config{
+		InsecureSkipVerify: true,
+	}); err == nil {
+		conn.Close()
+		t.Fatal("listener should not be support tls any more")
 	}
 }

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -21,6 +21,7 @@ import (
 	"container/list"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -30,7 +31,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/filter/accept/originaldst"
 	"github.com/alipay/sofa-mosn/pkg/log"
@@ -125,44 +126,53 @@ func (ch *connHandler) AddOrUpdateListener(lc *v2.Listener, networkFiltersFactor
 	var al *activeListener
 	if al = ch.findActiveListenerByName(listenerName); al != nil {
 		// listener already exist, update the listener
+		// NOTE:
+		// update network filters and stream filters maybe casue some unexpected effects, do not support currently
+		// just support to update log, access log and tls config and other simple config
 
 		// a listener with the same name must have the same configured address
 		if al.listener.Addr().String() != lc.Addr.String() ||
 			al.listener.Addr().Network() != lc.Addr.Network() {
-			return nil, fmt.Errorf("error updating listener, listen address and listen name doesn't match")
+			return nil, errors.New("error updating listener, listen address and listen name doesn't match")
 		}
-
-		equalConfig := reflect.DeepEqual(al.listener.Config(), lc)
-		equalNetworkFilter := reflect.DeepEqual(al.networkFiltersFactories, networkFiltersFactories)
-		equalStreamFilters := reflect.DeepEqual(al.streamFiltersFactories, streamFiltersFactories)
-		// duplicate config does nothing
-		if equalConfig && equalNetworkFilter && equalStreamFilters {
-			log.DefaultLogger.Debugf("duplicate listener:%s found. no add/update", listenerName)
-			return nil, nil
+		// currently, we just support one filter chain
+		if len(lc.FilterChains) != 1 {
+			return nil, errors.New("error updating listener, listener have filter chains count is not 1")
 		}
+		rawConfig := al.listener.Config()
+		// FIXME: update log level need the pkg/logger support.
 
-		// update some config, and as Address and Name doesn't change , so need't change *rawl
+		// tls update only take effects on new connections
+		tlsChanged := false
+		if !reflect.DeepEqual(rawConfig.FilterChains[0].TLS, lc.FilterChains[0].TLS) {
+			rawConfig.FilterChains[0].TLS = lc.FilterChains[0].TLS
+			tlsChanged = true
+		}
+		if rawConfig.Inspector != lc.Inspector {
+			rawConfig.Inspector = lc.Inspector
+			tlsChanged = true
+		}
+		if tlsChanged {
+			mgr, err := mtls.NewTLSServerContextManager(rawConfig, al.listener, al.logger)
+			if err != nil {
+				al.logger.Errorf("create tls context manager failed, %v", err)
+				return nil, err
+			}
+			al.tlsMng = mgr
+		}
+		// some simle config update
+		rawConfig.PerConnBufferLimitBytes = lc.PerConnBufferLimitBytes
+		al.listener.SetPerConnBufferLimitBytes(lc.PerConnBufferLimitBytes)
+		rawConfig.ListenerTag = lc.ListenerTag
+		al.listener.SetListenerTag(lc.ListenerTag)
+		rawConfig.HandOffRestoredDestinationConnections = lc.HandOffRestoredDestinationConnections
+		al.listener.SetHandOffRestoredDestinationConnections(lc.HandOffRestoredDestinationConnections)
+
+		al.listener.SetConfig(rawConfig)
+
+		// set update label to true, do not start the listener again
 		al.updatedLabel = true
-		if !equalConfig {
-			al.disableConnIo = lc.DisableConnIo
-			al.listener.SetConfig(lc)
-			al.listener.SetPerConnBufferLimitBytes(lc.PerConnBufferLimitBytes)
-			al.listener.SetListenerTag(lc.ListenerTag)
-			al.listener.SetHandOffRestoredDestinationConnections(lc.HandOffRestoredDestinationConnections)
-			log.DefaultLogger.Debugf("AddOrUpdateListener: use new listen config = %+v", lc)
-		}
 
-		// update network filter
-		if !equalNetworkFilter {
-			al.networkFiltersFactories = networkFiltersFactories
-			log.DefaultLogger.Debugf("AddOrUpdateListener: use new networkFiltersFactories = %+v", networkFiltersFactories)
-		}
-
-		// update stream filter
-		if !equalStreamFilters {
-			al.streamFiltersFactories = streamFiltersFactories
-			log.DefaultLogger.Debugf("AddOrUpdateListener: use new streamFiltersFactories = %+v", streamFiltersFactories)
-		}
 	} else {
 		// listener doesn't exist, add the listener
 		//TODO: connection level stop-chan usage confirm
@@ -203,7 +213,7 @@ func (ch *connHandler) AddOrUpdateListener(lc *v2.Listener, networkFiltersFactor
 		l.SetListenerCallbacks(al)
 		ch.listeners = append(ch.listeners, al)
 	}
-	admin.SetListenerConfig(listenerName, *lc)
+	admin.SetListenerConfig(listenerName, *al.listener.Config())
 	return al, nil
 }
 

--- a/pkg/server/mock_test.go
+++ b/pkg/server/mock_test.go
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+
+	"github.com/alipay/sofa-mosn/pkg/types"
+)
+
+type mockClusterManager struct {
+	types.ClusterManager
+}
+
+type mockClusterManagerFilter struct {
+	cccb types.ClusterConfigFactoryCb
+	chcb types.ClusterHostFactoryCb
+}
+
+func (cmf *mockClusterManagerFilter) OnCreated(cccb types.ClusterConfigFactoryCb, chcb types.ClusterHostFactoryCb) {
+	cmf.cccb = cccb
+	cmf.chcb = chcb
+}
+
+type mockNetworkFilter struct{}
+
+func (nf *mockNetworkFilter) OnData(buffer types.IoBuffer) types.FilterStatus {
+	return types.Stop
+}
+func (nf *mockNetworkFilter) OnNewConnection() types.FilterStatus {
+	return types.Continue
+}
+func (nf *mockNetworkFilter) InitializeReadFilterCallbacks(cb types.ReadFilterCallbacks) {}
+
+type mockNetworkFilterFactory struct{}
+
+func (ff *mockNetworkFilterFactory) CreateFilterChain(context context.Context, clusterManager types.ClusterManager, callbacks types.NetWorkFilterChainFactoryCallbacks) {
+	callbacks.AddReadFilter(&mockNetworkFilter{})
+}
+
+const mockCAPEM = `-----BEGIN CERTIFICATE-----
+MIIC4jCCAcqgAwIBAgIQdme9dUKPZVTgfIVpy+fmmjANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMB4XDTE5MDIyMDA3NTMyOFoXDTIwMDIyMDA3NTMy
+OFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAK/6yPpumKMxdVJU1y4ssNaqCp1NWJogss7cnF6YJHxYI64UXPnbAcSw
+oWxnIKqjtY6c+6tT2G3HRrHB+gE3jv7aVcUf0wyXSWMoUfzGKoigPbPHSdSS3Ri8
++snJz3+tnJkmL4Mso0c8MBcdX8+65FTDTxk9wV0ZWjNty0kf+udyJb8gEaHOTsjS
+XypqFc+GIezjpQICqWNdFHILf+F/WgVT4iHfxUlZBlXQxA945dS6v6pEcKF07Tqv
+UEVSVO5QC42l/8ahCmwSbzWckX12dVvKbEKRsyDUxP/BzZBTd6fTcD6KQgdOdofz
+LkNxegY0UP/d9KzvKdbNATo6TK34OlUCAwEAAaM0MDIwDgYDVR0PAQH/BAQDAgKk
+MA8GA1UdEwEB/wQFMAMBAf8wDwYDVR0RBAgwBocEfwAAATANBgkqhkiG9w0BAQsF
+AAOCAQEAYMi10S2KT5EH9o0GxmbSWLArarHFtBME2HdYip1p8+uW+J5KNqk97yEa
+Naqy74bekBlD7rWmUnhJM6hCHvYYzoqGaiFVp8LbRtH4vCNG1slL/OMyleGyLJ/Z
+pYK19tjyMk2HLwz9LMVVqDohk1hCpWIene1+hhNhVSqv2VAI3q176T4vNrXtcgXr
+xO8EIu/BnMMLPFSTlSAiJ5VHZITRfHSbabrr65onOR3JxoO65+UnIT05yHI1RDsn
+aJ16S3TSuSNRabZ+ji9BNhIP3DzPMIIGfmrev3wcgZsJB/ZmjRMIbALiwEoW1z8h
+BZljtrz0tsrbWvYDKMvVOeDGghy/KQ==
+-----END CERTIFICATE-----`
+
+const mockCertPEM = `-----BEGIN CERTIFICATE-----
+MIIC/jCCAeagAwIBAgIQdme9dUKPZVTgfIVpy+fmmjANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMB4XDTE5MDIyMDA3NTMyOFoXDTIwMDIyMDA3NTMy
+OFowEjEQMA4GA1UEChMHQWNtZSBDbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
+AQoCggEBAK/6yPpumKMxdVJU1y4ssNaqCp1NWJogss7cnF6YJHxYI64UXPnbAcSw
+oWxnIKqjtY6c+6tT2G3HRrHB+gE3jv7aVcUf0wyXSWMoUfzGKoigPbPHSdSS3Ri8
++snJz3+tnJkmL4Mso0c8MBcdX8+65FTDTxk9wV0ZWjNty0kf+udyJb8gEaHOTsjS
+XypqFc+GIezjpQICqWNdFHILf+F/WgVT4iHfxUlZBlXQxA945dS6v6pEcKF07Tqv
+UEVSVO5QC42l/8ahCmwSbzWckX12dVvKbEKRsyDUxP/BzZBTd6fTcD6KQgdOdofz
+LkNxegY0UP/d9KzvKdbNATo6TK34OlUCAwEAAaNQME4wDgYDVR0PAQH/BAQDAgWg
+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMA8G
+A1UdEQQIMAaHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAJkBEahCiyNAAAsoDgJy
+oYVr9W4FgrX1VMM5DFG6jX4aw4oDC91ZEqNK6VYkO1QIsSaLELBZZ+oB6kgM8N/4
+VgQnOJup8s0MAktJjudxQO81BYCnONKxktOUblj+kl4qOy6W8BH2yQ5gZO25ZTE1
+4hKuGRJIK2WGvDYye5SHmjnGUDmM3dVTSmIc8UmXP/xDtDZwHxj2BarkrHwf9k5/
+Q0WtzclIj4DUNh19FbSVq+zFJnPHDdhoo9zgkW7vDSutd41F3euCLtKwng02CLkw
+g+H3xKcfGv2gNrL7u8ej5l4dfWtWRsmLAG3FEUqsRBfG1PMX3QmB2AUpArfJE7Pu
+nCQ=
+-----END CERTIFICATE-----`
+
+const mockKeyPEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAr/rI+m6YozF1UlTXLiyw1qoKnU1YmiCyztycXpgkfFgjrhRc
++dsBxLChbGcgqqO1jpz7q1PYbcdGscH6ATeO/tpVxR/TDJdJYyhR/MYqiKA9s8dJ
+1JLdGLz6ycnPf62cmSYvgyyjRzwwFx1fz7rkVMNPGT3BXRlaM23LSR/653IlvyAR
+oc5OyNJfKmoVz4Yh7OOlAgKpY10Ucgt/4X9aBVPiId/FSVkGVdDED3jl1Lq/qkRw
+oXTtOq9QRVJU7lALjaX/xqEKbBJvNZyRfXZ1W8psQpGzINTE/8HNkFN3p9NwPopC
+B052h/MuQ3F6BjRQ/930rO8p1s0BOjpMrfg6VQIDAQABAoIBAQCGHAB9mTsJYu+d
+xroVnklFzmA4cHFNRA4AR2+DRz7G5ASM7UfNwXEfi9v42L60S/5YqJnCfys4vdzK
+KqFzu/tljM5AY3ha6BAtWNTiZcKUTEm5b+576VBFQf99OCbBjnUA4XDj7migKOYd
+N22EyVCoqA7nlYB+iouLFekN2SlEpxx5Nj8QLqHUReV9vpU+vBfK/OdkLoaZOECS
+ffMWSRxYrS01XW0hp/MTtpGwayt1mNvj36+Gwn3Z5p967uXy7qK0bxn8IJYHbe3F
+Tv3SRSLf2do3CEYyanpEv7J3QMtwZeanHwumMotvrP8gQpiK55QldEzvpW9JoHa7
+gU+nOncBAoGBAOPojo9yQLzzkZFAmZNMcQn7DuVD7iEGw1AFtr8yhmVbjNcuXJoq
+isaCxnwJRvkBmf9U+tpMDoxOT1IOjGUCfVuTncmpd3Qydxt+xq2/kf1scptygqQl
+bjQ06N64BmvMVys31tS+EFhRSJR8esTzkwmqI3bB+tUdQi2C8qn7DHtZAoGBAMWr
+qYlerj23CH6B1/UjKaUh/SssJpoeXAtO7/j2gZ1vNpb5Mt20soFKxN8i38+04mon
+yyYGvX4Y1+2ju/fd8ILFvYG2WPAHJi/7P/81ktcgCKnkwQnXrlfMUEOmi0eOTi8P
+8GN1dM/CAJikogaleLqJJcrInsxNiLFfpmJRHGNdAoGAMLwD8AygZ0c2M3c639KS
+wW2cC85w10MY9L2kDFKDhp0DCuhxCM5cCoLgapmZQZnkEkNbuN5Wpg4AzC0sPFVB
+9Rklvn+seX5pFcoQNgsm7qgIAdGEuhD+9c7ylN2JEfgKE8XG/Ir/98K54HaV0hO7
+t29YUga82mF9SzobJdn3G1ECgYBqD31b861R989a8ZhKM5+4ts/8RihAMWH5v1UL
+JFjPfEiyIOumAbp1nQSdJT0pWUjS5J8fvCYYboQNQfktOaw+vpK78nct8ugOfqUL
+7lbnjoyXe+IHwe4NtdarNcUtk7FnlwnIk9ElWFaxkERPhKGOlN/uOk7aGA/r/AJu
+Zk7xEQKBgDh4B7wTVi6eKRDYJpgWiDgT5uV0gu60mJ0CHYmjUtX9RGBsGS85zJmx
+2JMjNOmrivQ3dvL/rNKIx0ULx+iTQr3Y6B8A2xCme3yr665arvE0HOFG0hLVE1a0
+wD08P7/0q7yk5M4dDUwerGaTIRKK8RRFy1Ak9kU6EtHsbUKNo9s5
+-----END RSA PRIVATE KEY-----`

--- a/pkg/server/stoppable.go
+++ b/pkg/server/stoppable.go
@@ -18,7 +18,7 @@
 package server
 
 import (
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/types"
 )
 

--- a/pkg/upstream/cluster/clustermanager.go
+++ b/pkg/upstream/cluster/clustermanager.go
@@ -25,12 +25,12 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/log"
+	"github.com/alipay/sofa-mosn/pkg/network"
 	"github.com/alipay/sofa-mosn/pkg/rcu"
 	"github.com/alipay/sofa-mosn/pkg/types"
-	"github.com/alipay/sofa-mosn/pkg/network"
 )
 
 var instanceMutex = sync.Mutex{}

--- a/test/integrate/functiontest/tls_update_test.go
+++ b/test/integrate/functiontest/tls_update_test.go
@@ -1,0 +1,397 @@
+package functiontest
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	"github.com/alipay/sofa-mosn/pkg/config"
+	"github.com/alipay/sofa-mosn/pkg/mosn"
+	"github.com/alipay/sofa-mosn/pkg/protocol"
+	_ "github.com/alipay/sofa-mosn/pkg/protocol/http/conv"
+	_ "github.com/alipay/sofa-mosn/pkg/protocol/http2/conv"
+	_ "github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc/codec"
+	_ "github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc/conv"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/http"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/http2"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/sofarpc"
+	_ "github.com/alipay/sofa-mosn/pkg/stream/xprotocol"
+	"github.com/alipay/sofa-mosn/pkg/types"
+	"github.com/alipay/sofa-mosn/test/util"
+	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/net/http2"
+)
+
+const (
+	caPEM = `-----BEGIN CERTIFICATE-----
+MIIBVzCB/qADAgECAhBsIQij0idqnmDVIxbNRxRCMAoGCCqGSM49BAMCMBIxEDAO
+BgNVBAoTB0FjbWUgQ28wIBcNNzAwMTAxMDAwMDAwWhgPMjA4NDAxMjkxNjAwMDBa
+MBIxEDAOBgNVBAoTB0FjbWUgQ28wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARV
+DG+YT6LzaR5r0Howj4/XxHtr3tJ+llqg9WtTJn0qMy3OEUZRfHdP9iuJ7Ot6rwGF
+i6RXy1PlAurzeFzDqQY8ozQwMjAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUw
+AwEB/zAPBgNVHREECDAGhwR/AAABMAoGCCqGSM49BAMCA0gAMEUCIQDt9WA96LJq
+VvKjvGhhTYI9KtbC0X+EIFGba9lsc6+ubAIgTf7UIuFHwSsxIVL9jI5RkNgvCA92
+FoByjq7LS7hLSD8=
+-----END CERTIFICATE-----
+`
+	certPEM = `-----BEGIN CERTIFICATE-----
+MIIBdDCCARqgAwIBAgIQbCEIo9Inap5g1SMWzUcUQjAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYwMDAw
+WjASMRAwDgYDVQQKEwdBY21lIENvMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+VQxvmE+i82kea9B6MI+P18R7a97SfpZaoPVrUyZ9KjMtzhFGUXx3T/Yriezreq8B
+hYukV8tT5QLq83hcw6kGPKNQME4wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQG
+CCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMA8GA1UdEQQIMAaHBH8A
+AAEwCgYIKoZIzj0EAwIDSAAwRQIgO9xLIF1AoBsSMU6UgNE7svbelMAdUQgEVIhq
+K3gwoeICIQCDC75Fa3XQL+4PZatS3OfG93XNFyno9koyn5mxLlDAAg==
+-----END CERTIFICATE-----
+`
+	keyPEM = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICWksdaVL6sOu33VeohiDuQ3gP8xlQghdc+2FsWPSkrooAoGCCqGSM49
+AwEHoUQDQgAEVQxvmE+i82kea9B6MI+P18R7a97SfpZaoPVrUyZ9KjMtzhFGUXx3
+T/Yriezreq8BhYukV8tT5QLq83hcw6kGPA==
+-----END EC PRIVATE KEY-----
+`
+)
+
+// for test tls update, we use a client - tls -> mosn -> upstream server
+// protocol include http/http2/sofarpc(boltv1)
+// FIXME: mosn listen http2 with tls have bugs.(no alpn)
+// case1 mosn listen a non-tls changed to tls (needs to create new connection)
+// case2 mosn listen a tls (without inspector) changed to non-tls (needs to create new connection)
+// case3 mosn listen a tls (without inspector) changed to inspector mode
+type TLSUpdateCase struct {
+	Protocol     types.Protocol
+	AppServer    util.UpstreamServer
+	MeshAddr     string
+	ListenerName string
+	C            chan error
+	T            *testing.T
+	Stop         chan struct{}
+}
+
+func NewTLSUpdateCase(t *testing.T, proto types.Protocol, server util.UpstreamServer) *TLSUpdateCase {
+	return &TLSUpdateCase{
+		Protocol:  proto,
+		AppServer: server,
+		C:         make(chan error),
+		T:         t,
+		Stop:      make(chan struct{}),
+	}
+}
+
+var DefaultTLSConfig = v2.TLSConfig{
+	Status:     true,
+	CACert:     caPEM,
+	CertChain:  certPEM,
+	PrivateKey: keyPEM,
+	ServerName: "127.0.0.1",
+}
+
+func MakeProxyWithTLSConfig(listenerName string, addr string, hosts []string, proto types.Protocol, tls bool) *config.MOSNConfig {
+	clusterName := "upstream"
+	cmconfig := config.ClusterManagerConfig{
+		Clusters: []v2.Cluster{
+			util.NewBasicCluster(clusterName, hosts),
+		},
+	}
+	routers := []v2.Router{
+		util.NewPrefixRouter(clusterName, "/"),
+		util.NewHeaderRouter(clusterName, ".*"),
+	}
+	filterChain := util.NewFilterChain("proxyVirtualHost", proto, proto, routers)
+	if tls {
+		filterChain.TLS = DefaultTLSConfig
+	}
+	chains := []v2.FilterChain{filterChain}
+	lnCfg := util.NewListener(listenerName, addr, chains)
+	lnCfg.Inspector = false
+	mosnConfig := util.NewMOSNConfig([]v2.Listener{lnCfg}, cmconfig)
+	mosnConfig.RawAdmin = jsoniter.RawMessage([]byte(`{
+		 "address":{
+			 "socket_address":{
+				 "address": "127.0.0.1",
+				 "port_value": 8888
+			 }
+		 }
+	}`))
+	return mosnConfig
+
+}
+
+func (c *TLSUpdateCase) Start(tls bool) {
+	c.AppServer.GoServe()
+	appAddr := c.AppServer.Addr()
+	c.MeshAddr = util.CurrentMeshAddr()
+	c.ListenerName = "test_dynamic"
+	cfg := MakeProxyWithTLSConfig(c.ListenerName, c.MeshAddr, []string{appAddr}, c.Protocol, tls)
+	mesh := mosn.NewMosn(cfg)
+	go mesh.Start()
+	go func() {
+		<-c.Stop
+		c.AppServer.Close()
+		mesh.Close()
+	}()
+	time.Sleep(5 * time.Second) //wait server and mesh start
+}
+
+type tlsUpdate struct {
+	Listener  string       `json:"listener"`
+	Inspetcor bool         `json:"inspetcor"`
+	TLSConfig v2.TLSConfig `json:"tls_context"`
+}
+
+func (c *TLSUpdateCase) UpdateTLS(inspector bool, cfg *v2.TLSConfig) error {
+	data := tlsUpdate{
+		Listener:  c.ListenerName,
+		Inspetcor: inspector,
+		TLSConfig: *cfg,
+	}
+	b, _ := json.Marshal(data)
+	buf := bytes.NewBuffer(b)
+	resp, err := http.Post("http://127.0.0.1:8888/api/v1/tls", "application/x-www-form-urlencoded; charset=UTF-8", buf)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("update failed")
+	}
+	return nil
+}
+
+// client do "n" times request, interval time (ms)
+func (c *TLSUpdateCase) RequestTLS(isTLS bool, n int, interval int) {
+	var call func() error
+	switch c.Protocol {
+	case protocol.HTTP1:
+		tr := http.DefaultTransport.(*http.Transport)
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM([]byte(caPEM))
+		tr.TLSClientConfig = &tls.Config{
+			RootCAs: pool,
+		}
+		httpClient := http.Client{
+			Transport: tr,
+		}
+		call = func() error {
+			scheme := "http://"
+			if isTLS {
+				scheme = "https://"
+			}
+			resp, err := httpClient.Get(fmt.Sprintf("%s%s/", scheme, c.MeshAddr))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("response status: %d", resp.StatusCode)
+			}
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			c.T.Logf("HTTP client receive data: %s\n", string(b))
+			return nil
+		}
+	case protocol.HTTP2:
+		var httpClient http.Client
+		if !isTLS {
+			tr := &http2.Transport{
+				AllowHTTP: true,
+				DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
+					return net.Dial(netw, addr)
+				},
+			}
+			httpClient = http.Client{Transport: tr}
+
+		} else {
+			pool := x509.NewCertPool()
+			pool.AppendCertsFromPEM([]byte(caPEM))
+			httpClient = http.Client{
+				Transport: &http2.Transport{
+					TLSClientConfig: &tls.Config{
+						RootCAs: pool,
+					},
+				},
+			}
+		}
+		call = func() error {
+			scheme := "http://"
+			if isTLS {
+				scheme = "https://"
+			}
+			resp, err := httpClient.Get(fmt.Sprintf("%s%s/", scheme, c.MeshAddr))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("response status: %d", resp.StatusCode)
+
+			}
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			c.T.Logf("HTTP2 client receive data: %s\n", string(b))
+			return nil
+		}
+	case protocol.SofaRPC:
+		server, ok := c.AppServer.(*util.RPCServer)
+		if !ok {
+			c.C <- fmt.Errorf("need a sofa rpc server")
+			return
+		}
+		client := server.Client
+		if isTLS {
+			tlsCfg := &v2.TLSConfig{
+				Status:     true,
+				CACert:     caPEM,
+				ServerName: "127.0.0.1",
+			}
+			if err := client.ConnectTLS(c.MeshAddr, tlsCfg); err != nil {
+				c.C <- err
+				return
+			}
+		} else {
+			if err := client.Connect(c.MeshAddr); err != nil {
+				c.C <- err
+				return
+			}
+		}
+		defer client.Close() // close the connection
+		call = func() error {
+			client.SendRequest()
+			if !util.WaitMapEmpty(&client.Waits, 2*time.Second) {
+				return fmt.Errorf("request get no response")
+			}
+			return nil
+		}
+	}
+	for i := 0; i < n; i++ {
+		if err := call(); err != nil {
+			c.C <- err
+			return
+		}
+		time.Sleep(time.Duration(interval) * time.Millisecond)
+	}
+	c.C <- nil
+}
+
+// NoneToTLS
+// first listen a non-tls listener, then update to tls
+func TestUpdateTLS_NoneToTLS(t *testing.T) {
+	appaddr := "127.0.0.1:8080"
+	testCases := []*TLSUpdateCase{
+		NewTLSUpdateCase(t, protocol.HTTP1, util.NewHTTPServer(t, nil)),
+		// NewTLSUpdateCase(t, protocol.HTTP2, util.NewUpstreamHTTP2(t, appaddr, nil)),
+		NewTLSUpdateCase(t, protocol.SofaRPC, util.NewRPCServer(t, appaddr, util.Bolt1)),
+	}
+	for i, tc := range testCases {
+		verify := func() {
+			select {
+			case err := <-tc.C:
+				if err != nil {
+					t.Errorf("request failed, case %d, protocol %v, error: %v", i, tc.Protocol, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Errorf("request hung up case %d, protocol %v", i, tc.Protocol)
+			}
+		}
+		t.Logf("start case #%d\n", i)
+		tc.Start(false)
+		go tc.RequestTLS(false, 1, 0)
+		t.Logf("verify non-tls")
+		verify()
+		// update to tls
+		if err := tc.UpdateTLS(false, &DefaultTLSConfig); err != nil {
+			t.Fatal("update tls failed")
+		}
+		go tc.RequestTLS(true, 1, 0)
+		t.Logf("verify tls")
+		verify()
+		close(tc.Stop)
+		time.Sleep(time.Second)
+
+	}
+}
+
+// TLSToNone
+// first listen a tls listener, then update to non-tls
+func TestUpdateTLS_TLSToNone(t *testing.T) {
+	appaddr := "127.0.0.1:8080"
+	testCases := []*TLSUpdateCase{
+		NewTLSUpdateCase(t, protocol.HTTP1, util.NewHTTPServer(t, nil)),
+		// NewTLSUpdateCase(t, protocol.HTTP2, util.NewUpstreamHTTP2(t, appaddr, nil)),
+		NewTLSUpdateCase(t, protocol.SofaRPC, util.NewRPCServer(t, appaddr, util.Bolt1)),
+	}
+	for i, tc := range testCases {
+		verify := func() {
+			select {
+			case err := <-tc.C:
+				if err != nil {
+					t.Errorf("request failed, case %d, protocol %v, error: %v", i, tc.Protocol, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Errorf("request hung up case %d, protocol %v", i, tc.Protocol)
+			}
+		}
+		t.Logf("start case #%d\n", i)
+		tc.Start(true)
+		go tc.RequestTLS(true, 1, 0)
+		verify()
+		// update to non-tls
+		if err := tc.UpdateTLS(false, &v2.TLSConfig{}); err != nil {
+			t.Fatal("update tls failed")
+		}
+		go tc.RequestTLS(false, 1, 0)
+		verify()
+		// finish
+		close(tc.Stop)
+		time.Sleep(time.Second)
+	}
+
+}
+
+// TLS to inspector
+func TestUpdateTLS_TLSToInspector(t *testing.T) {
+	appaddr := "127.0.0.1:8080"
+	testCases := []*TLSUpdateCase{
+		NewTLSUpdateCase(t, protocol.HTTP1, util.NewHTTPServer(t, nil)),
+		// NewTLSUpdateCase(t, protocol.HTTP2, util.NewUpstreamHTTP2(t, appaddr, nil)),
+		NewTLSUpdateCase(t, protocol.SofaRPC, util.NewRPCServer(t, appaddr, util.Bolt1)),
+	}
+	for i, tc := range testCases {
+		verify := func() {
+			select {
+			case err := <-tc.C:
+				if err != nil {
+					t.Errorf("request failed, case %d, protocol %v, error: %v", i, tc.Protocol, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Errorf("request hung up case %d, protocol %v", i, tc.Protocol)
+			}
+		}
+		t.Logf("start case #%d\n", i)
+		tc.Start(true)
+		go tc.RequestTLS(true, 1, 0)
+		verify()
+		// update to inspector
+		if err := tc.UpdateTLS(true, &DefaultTLSConfig); err != nil {
+			t.Fatal("update tls failed")
+		}
+		go tc.RequestTLS(false, 1, 0)
+		verify()
+		close(tc.Stop)
+		time.Sleep(time.Second)
+
+	}
+}

--- a/test/integrate/functiontest/tls_update_test.go
+++ b/test/integrate/functiontest/tls_update_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/alipay/sofa-mosn/pkg/protocol/http2/conv"
 	_ "github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc/codec"
 	_ "github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc/conv"
+	"github.com/alipay/sofa-mosn/pkg/server"
 	_ "github.com/alipay/sofa-mosn/pkg/stream/http"
 	_ "github.com/alipay/sofa-mosn/pkg/stream/http2"
 	_ "github.com/alipay/sofa-mosn/pkg/stream/sofarpc"
@@ -132,6 +133,8 @@ func (c *TLSUpdateCase) Start(tls bool) {
 	c.MeshAddr = util.CurrentMeshAddr()
 	c.ListenerName = "test_dynamic"
 	cfg := MakeProxyWithTLSConfig(c.ListenerName, c.MeshAddr, []string{appAddr}, c.Protocol, tls)
+	// for test, reset adapter
+	server.ResetAdapter()
 	mesh := mosn.NewMosn(cfg)
 	go mesh.Start()
 	go func() {
@@ -392,6 +395,5 @@ func TestUpdateTLS_TLSToInspector(t *testing.T) {
 		verify()
 		close(tc.Stop)
 		time.Sleep(time.Second)
-
 	}
 }

--- a/test/integrate/functiontest/tls_update_test.go
+++ b/test/integrate/functiontest/tls_update_test.go
@@ -1,10 +1,8 @@
 package functiontest
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -145,29 +143,9 @@ func (c *TLSUpdateCase) Start(tls bool) {
 	time.Sleep(5 * time.Second) //wait server and mesh start
 }
 
-type tlsUpdate struct {
-	Listener  string       `json:"listener"`
-	Inspetcor bool         `json:"inspetcor"`
-	TLSConfig v2.TLSConfig `json:"tls_context"`
-}
-
 func (c *TLSUpdateCase) UpdateTLS(inspector bool, cfg *v2.TLSConfig) error {
-	data := tlsUpdate{
-		Listener:  c.ListenerName,
-		Inspetcor: inspector,
-		TLSConfig: *cfg,
-	}
-	b, _ := json.Marshal(data)
-	buf := bytes.NewBuffer(b)
-	resp, err := http.Post("http://127.0.0.1:8888/api/v1/tls", "application/x-www-form-urlencoded; charset=UTF-8", buf)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return errors.New("update failed")
-	}
-	return nil
+	adapter := server.GetListenerAdapterInstance()
+	return adapter.UpdateListenerTLS("", c.ListenerName, inspector, cfg)
 }
 
 // client do "n" times request, interval time (ms)

--- a/test/integrate/xds_config_test.go
+++ b/test/integrate/xds_config_test.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/alipay/sofa-mosn/pkg/admin"
+	admin "github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/config"
 	_ "github.com/alipay/sofa-mosn/pkg/filter/stream/faultinject"


### PR DESCRIPTION
## 改动内容
+ 支持Listener中TLS配置的动态更新。 更新以后，对Listener中新建的连接，将采用新的TLS配置。
+ 同时删除了一些Listener中动态更新可能存在问题的部分，有问题的部分主要是NetworkFilters和StreamFilters的更新部分，修改为传入空则不更新，非空就更新；同时更新对应的配置
+ 修改了admin包的结构，主要是为了解决循环依赖的问题
+ admin server的启动从main移动到了mosn的包中
## 关于测试
补充了UT与集成测试
其中集成测试中，采用client->mosn->server的模式，通过动态更新的API 更新TLS监听状态。 在测试过程中发现MOSN以HTTP2 & TLS的方式监听时，无法直接用go的http2 client进行访问，需要在以后fix
