### PR TITLE
support service( pprof, adminApi, metric) inherit listen FD

### DIFF
--- a/cmd/mosn/main/control.go
+++ b/cmd/mosn/main/control.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/config"
-	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/mosn"
 	"github.com/urfave/cli"
 )
@@ -61,12 +60,8 @@ var (
 					port = conf.Debug.Port
 				}
 				addr := fmt.Sprintf("0.0.0.0:%d", port)
-				store.AddStartService(func() {
-					log.StartLogger.Infof("start a pprof server %s", addr)
-					s := &http.Server{Addr: addr, Handler: nil}
-					store.AddStopService(s)
-					s.ListenAndServe()
-				})
+				s := &http.Server{Addr: addr, Handler: nil}
+				store.AddService(s, "pprof", nil, nil)
 			}
 			mosn.Start(conf, serviceCluster, serviceNode)
 			return nil

--- a/pkg/admin/server/server.go
+++ b/pkg/admin/server/server.go
@@ -62,7 +62,3 @@ func (s *Server) Start(config Config) {
 	store.AddService(srv, "Mosn Admin Server", nil, nil)
 	s.Server = srv
 }
-
-func (s *Server) Close() error {
-	return s.Server.Close()
-}

--- a/pkg/admin/server/server_test.go
+++ b/pkg/admin/server/server_test.go
@@ -140,14 +140,15 @@ func (m *mockMOSNConfig) GetAdmin() *v2.Admin {
 }
 
 func TestDumpConfig(t *testing.T) {
+	time.Sleep(time.Second)
 	server := Server{}
 	config := &mockMOSNConfig{
 		Name: "mock",
 		Port: 8889,
 	}
 	server.Start(config)
-	store.StartService()
-	defer server.Close()
+	store.StartService(nil)
+	defer store.StopService()
 
 	time.Sleep(time.Second) //wait server start
 
@@ -162,14 +163,15 @@ func TestDumpConfig(t *testing.T) {
 }
 
 func TestDumpStats(t *testing.T) {
+	time.Sleep(time.Second)
 	server := Server{}
 	config := &mockMOSNConfig{
 		Name: "mock",
 		Port: 8889,
 	}
 	server.Start(config)
-	store.StartService()
-	defer server.Close()
+	store.StartService(nil)
+	defer store.StopService()
 
 	time.Sleep(time.Second) //wait server start
 
@@ -197,14 +199,15 @@ func TestDumpStats(t *testing.T) {
 }
 
 func TestUpdateLogger(t *testing.T) {
+	time.Sleep(time.Second)
 	server := Server{}
 	config := &mockMOSNConfig{
 		Name: "mock",
 		Port: 8889,
 	}
 	server.Start(config)
-	store.StartService()
-	defer server.Close()
+	store.StartService(nil)
+	defer store.StopService()
 
 	time.Sleep(time.Second) //wait server start
 
@@ -227,14 +230,15 @@ func TestUpdateLogger(t *testing.T) {
 }
 
 func TestToggleLogger(t *testing.T) {
+	time.Sleep(time.Second)
 	server := Server{}
 	config := &mockMOSNConfig{
 		Name: "mock",
 		Port: 8889,
 	}
 	server.Start(config)
-	store.StartService()
-	defer server.Close()
+	store.StartService(nil)
+	defer store.StopService()
 
 	time.Sleep(time.Second) //wait server start
 

--- a/pkg/admin/store/dump.go
+++ b/pkg/admin/store/dump.go
@@ -15,10 +15,16 @@
  * limitations under the License.
  */
 
-package types
+package store
 
+import "sync"
 
-// StopService is an interface for server/listener, which can be stopped when transfer
-type StopService interface {
-	Close() error
+var fileMutex = new(sync.Mutex)
+
+func DumpLock() {
+	fileMutex.Lock()
+}
+
+func DumpUnlock() {
+	fileMutex.Unlock()
 }

--- a/pkg/admin/store/service.go
+++ b/pkg/admin/store/service.go
@@ -18,37 +18,120 @@
 package store
 
 import (
-	"time"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
 
 	"github.com/alipay/sofa-mosn/pkg/log"
-	"github.com/alipay/sofa-mosn/pkg/types"
 )
 
-var startService []func()
-
-func AddStartService(f func()) {
-	startService = append(startService, f)
+type service struct {
+	*http.Server
+	name string
+	init func()
+	exit func()
 }
 
-func StartService() {
-	time.Sleep(2 * time.Second)
-	for _, f := range startService {
-		go f()
+var services []*service
+var listeners []net.Listener
+
+func ListServiceListenersFile() ([]*os.File, error) {
+	if len(listeners) == 0 {
+		return nil, nil
 	}
-	startService = startService[:0]
+
+	files := make([]*os.File, len(listeners))
+
+	for i, l := range listeners {
+		var ok bool
+		var tl *net.TCPListener
+		if tl, ok = l.(*net.TCPListener); !ok {
+			return nil, errors.New("listener type is error")
+		}
+		file, err := tl.File()
+		if err != nil {
+			log.DefaultLogger.Errorf("fail to get listener %s file descriptor: %v", tl.Addr().String(), err)
+			return nil, errors.New("fail to get listener fd") //stop reconfigure
+		}
+		files[i] = file
+	}
+	return files, nil
 }
 
-var stopService []types.StopService
+func AddService(s *http.Server, name string, init func(), exit func()) {
+	for i, srv := range services {
+		if srv.Addr == s.Addr {
+			services[i] = &service{s, name, init, exit}
+			return
+		}
+	}
+	services = append(services, &service{s, name, init, exit})
+}
 
-func AddStopService(s types.StopService) {
-	stopService = append(stopService, s)
+func StartService(inheritListeners []net.Listener) error {
+	for _, s := range services {
+		var err error
+		var ln net.Listener
+		var saddr *net.TCPAddr
+
+		saddr, err = net.ResolveTCPAddr("tcp", s.Addr)
+		if err != nil {
+			log.StartLogger.Fatalln("[inheritListener] not valid:", s.Addr)
+		}
+
+		for i, l := range inheritListeners {
+			if l == nil {
+				continue
+			}
+			addr, err := net.ResolveTCPAddr("tcp", l.Addr().String())
+			if err != nil {
+				log.StartLogger.Fatalln("[inheritListener] not valid: ", l.Addr().String())
+			}
+
+			if addr.Port == saddr.Port {
+				ln = l
+				inheritListeners[i] = nil
+				log.StartLogger.Infof("inherit listener addr: %s", ln.Addr().String())
+				break
+			}
+		}
+
+		if ln == nil {
+			ln, err = net.Listen("tcp", s.Addr)
+			if err != nil {
+				return err
+			}
+		}
+		listeners = append(listeners, ln)
+		if s.name != "" {
+			log.StartLogger.Infof("start service %s on %s", s.name, ln.Addr().String())
+		}
+		if s.init != nil {
+			s.init()
+		}
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.DefaultLogger.Errorf("service %s panic %v", s.name, r)
+				}
+			}()
+
+			s.Serve(ln)
+		}()
+	}
+	return nil
 }
 
 func StopService() {
-	for _, s := range stopService {
-		if err := s.Close(); err != nil {
-			log.DefaultLogger.Infof("close service error: %v", err)
+	for _, s := range services {
+		if s.exit != nil {
+			s.exit()
 		}
+		go s.Shutdown(context.Background())
 	}
-	stopService = stopService[:0]
+	services = services[:0]
+	listeners = listeners[:0]
+
 }

--- a/pkg/admin/store/service.go
+++ b/pkg/admin/store/service.go
@@ -133,5 +133,4 @@ func StopService() {
 	}
 	services = services[:0]
 	listeners = listeners[:0]
-
 }

--- a/pkg/admin/store/service_test.go
+++ b/pkg/admin/store/service_test.go
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package store
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestService(t *testing.T) {
+	var b bool
+	srv := &http.Server{
+		Addr:    "127.0.0.1:13476",
+		Handler: nil,
+	}
+	AddService(
+		srv,
+		"test",
+		func() {
+			b = true
+		},
+		func() {
+			b = false
+		})
+	StartService(nil)
+	if !b {
+		t.Errorf("TestService init func error")
+	}
+
+	files, err := ListServiceListenersFile()
+	if len(files) != 1 {
+		t.Errorf("TestService ListServiceListenersFile() error: %v", err)
+	}
+	StopService()
+	if b {
+		t.Errorf("TestService exit func error")
+	}
+
+}
+
+func TestServiceInherit(t *testing.T) {
+	mux1 := http.NewServeMux()
+	mux1.HandleFunc("/", handler1)
+	s := &http.Server{
+		Addr:    "127.0.0.1:13477",
+		Handler: mux1,
+	}
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		t.Errorf("TestService net.Listern error: %v", err)
+	}
+	go s.Serve(ln)
+
+	time.Sleep(time.Second)
+	rsp, err := http.Get("http://127.0.0.1:13477/")
+	if rsp == nil || rsp.StatusCode != 200 {
+		t.Errorf("TestService http.Get error: %v", rsp)
+	}
+
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/", handler2)
+	srv := &http.Server{
+		Addr:    "127.0.0.1:13477",
+		Handler: mux2,
+	}
+	AddService(srv, "test", nil, nil)
+
+	l := ln.(*net.TCPListener)
+	f, _ := l.File()
+	ll, _ := net.FileListener(f)
+	f.Close()
+
+	if err := StartService([]net.Listener{ll}); err != nil {
+		t.Errorf("TestService StartService error: %v", err)
+	}
+	// close old server
+	s.Shutdown(context.Background())
+
+	time.Sleep(time.Second)
+	rsp, err = http.Get("http://127.0.0.1:13477/")
+	if rsp == nil || rsp.StatusCode != 201 {
+		t.Errorf("TestService http.Get error: %v", rsp)
+	}
+
+	StopService()
+
+	time.Sleep(time.Second)
+	rsp, err = http.Get("http://127.0.0.1:13477/")
+	if err == nil {
+		t.Errorf("TestService http.Get should failed")
+	}
+
+}
+
+func handler1(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+}
+
+func handler2(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(201)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,7 +121,7 @@ func (c *MOSNConfig) Mode() Mode {
 }
 
 var (
-	configPath string
+	ConfigPath string
 	config     MOSNConfig
 )
 
@@ -143,7 +143,7 @@ func Load(path string) *MOSNConfig {
 	if err != nil {
 		log.Fatalln("load config failed, ", err)
 	}
-	configPath, _ = filepath.Abs(path)
+	ConfigPath, _ = filepath.Abs(path)
 	// translate to lower case
 	err = json.Unmarshal(content, &config)
 	if err != nil {

--- a/pkg/config/dumper.go
+++ b/pkg/config/dumper.go
@@ -19,20 +19,16 @@ package config
 
 import (
 	"io/ioutil"
-	"sync"
-
 	"github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/log"
 )
 
-var fileMutex = new(sync.Mutex)
-
 func dump(dirty bool) {
-	fileMutex.Lock()
-	defer fileMutex.Unlock()
+	store.DumpLock()
+	defer store.DumpUnlock()
 
 	if dirty {
-		//log.DefaultLogger.Println("dump config to: ", configPath)
+		//log.DefaultLogger.Println("dump config to: ", ConfigPath)
 		log.DefaultLogger.Debugf("dump config content: %+v", config)
 
 		//update mosn_config
@@ -40,7 +36,7 @@ func dump(dirty bool) {
 		//todo: ignore zero values in config struct @boqin
 		content, err := json.MarshalIndent(config, "", "  ")
 		if err == nil {
-			err = ioutil.WriteFile(configPath, content, 0644)
+			err = ioutil.WriteFile(ConfigPath, content, 0644)
 		}
 
 		if err != nil {

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -231,10 +231,8 @@ func TestParseListenerConfig(t *testing.T) {
 	}
 	defer listener.Close()
 	tcpListener := listener.(*net.TCPListener)
-	inherit := &v2.Listener{
-		Addr:            tcpListener.Addr(),
-		InheritListener: tcpListener,
-	}
+	var inherit []net.Listener
+	inherit = append(inherit, tcpListener)
 
 	lc := &v2.Listener{
 		ListenerConfig: v2.ListenerConfig{
@@ -242,7 +240,7 @@ func TestParseListenerConfig(t *testing.T) {
 			LogLevelConfig: "DEBUG",
 		},
 	}
-	ln := ParseListenerConfig(lc, []*v2.Listener{inherit})
+	ln := ParseListenerConfig(lc, inherit)
 	if !(ln.Addr != nil &&
 		ln.Addr.String() == tcpListener.Addr().String() &&
 		ln.PerConnBufferLimitBytes == 1<<15 &&
@@ -251,7 +249,7 @@ func TestParseListenerConfig(t *testing.T) {
 		t.Error("listener parse unexpected")
 		t.Log(ln.Addr.String(), ln.InheritListener != nil, ln.LogLevel)
 	}
-	if !inherit.Remain {
+	if inherit[0] != nil {
 		t.Error("no inherit listener")
 	}
 }

--- a/pkg/metrics/sink/prometheus/prometheus.go
+++ b/pkg/metrics/sink/prometheus/prometheus.go
@@ -90,18 +90,15 @@ func NewPromeSink(config *promConfig) types.MetricsSink {
 	}
 
 	// export http for prometheus
-	store.AddStartService(func() {
-		srvMux := http.NewServeMux()
-		srvMux.Handle(config.Endpoint, promhttp.HandlerFor(promReg, promhttp.HandlerOpts{}))
+	srvMux := http.NewServeMux()
+	srvMux.Handle(config.Endpoint, promhttp.HandlerFor(promReg, promhttp.HandlerOpts{}))
 
-		srv := &http.Server{
-			Addr:    fmt.Sprintf(":%d", config.Port),
-			Handler: srvMux,
-		}
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", config.Port),
+		Handler: srvMux,
+	}
 
-		store.AddStopService(srv)
-		srv.ListenAndServe()
-	})
+	store.AddService(srv, "prometheus", nil, nil)
 
 	return &promSink{
 		config:    config,

--- a/pkg/metrics/sink/prometheus/prometheus_test.go
+++ b/pkg/metrics/sink/prometheus/prometheus_test.go
@@ -92,7 +92,8 @@ func TestPrometheusMetrics(t *testing.T) {
 		DisableCollectProcess: true,
 		DisableCollectGo:      true,
 	})
-	store.StartService()
+	store.StartService(nil)
+	defer store.StopService()
 	time.Sleep(time.Second) // wait server start
 
 	tc := http.Client{}

--- a/pkg/metrics/transfer.go
+++ b/pkg/metrics/transfer.go
@@ -177,7 +177,7 @@ func TransferServer(gracefultime time.Duration, ch chan<- bool) {
 		}
 	}()
 	select {
-	case <-time.After(gracefultime + types.DefaultConnReadTimeout + 10*time.Second):
+	case <-time.After(2*gracefultime + types.DefaultConnReadTimeout + 10*time.Second):
 		log.DefaultLogger.Infof("transfer metrics server exit")
 	}
 }

--- a/pkg/mosn/starter.go
+++ b/pkg/mosn/starter.go
@@ -216,8 +216,10 @@ func (m *Mosn) Start() {
 
 // Close mosn's server
 func (m *Mosn) Close() {
-	// close admin
-	m.adminServer.Close()
+	// close service
+	store.StopService()
+
+	// stop mosn server
 	for _, srv := range m.servers {
 		srv.Close()
 	}

--- a/pkg/network/transfer.go
+++ b/pkg/network/transfer.go
@@ -99,7 +99,7 @@ func TransferServer(handler types.ConnectionHandler) {
 	}(handler)
 
 	select {
-	case <-time.After(TransferTimeout + types.DefaultConnReadTimeout + 10*time.Second):
+	case <-time.After(2*TransferTimeout + types.DefaultConnReadTimeout + 10*time.Second):
 		log.DefaultLogger.Infof("TransferServer exit")
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,8 +148,9 @@ func ListListenersFile() []*os.File {
 
 func WaitConnectionsDone(duration time.Duration) error {
 	// one duration wait for connection to active close
+	// two duration wait for connection to transfer
 	// DefaultConnReadTimeout wait for read timeout
-	timeout := time.NewTimer(duration + types.DefaultConnReadTimeout)
+	timeout := time.NewTimer(2*duration + types.DefaultConnReadTimeout)
 	StopConnection()
 	log.DefaultLogger.Infof("StopConnection")
 	select {

--- a/pkg/server/serverkeeper.go
+++ b/pkg/server/serverkeeper.go
@@ -27,6 +27,8 @@ import (
 	"syscall"
 	"time"
 
+	"net"
+
 	"github.com/alipay/sofa-mosn/pkg/admin/store"
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/metrics"
@@ -59,7 +61,7 @@ func SetPid(pid string) {
 }
 
 func storeOldPid() {
-	if b, err := ioutil.ReadFile(pidFile); err == nil {
+	if b, err := ioutil.ReadFile(pidFile); err == nil && len(b) > 0 {
 		// delete "\n"
 		oldPid, _ = strconv.Atoi(string(b[0 : len(b)-1]))
 	}
@@ -70,7 +72,7 @@ func WritePidFile() (err error) {
 
 	os.MkdirAll(MosnBasePath, 0644)
 
-	if err = ioutil.WriteFile(pidFile, pid, 0644); err!= nil {
+	if err = ioutil.WriteFile(pidFile, pid, 0644); err != nil {
 		log.DefaultLogger.Errorf("write pid file error: %v", err)
 	}
 	return err
@@ -187,8 +189,15 @@ func startNewMosn() error {
 }
 
 func reconfigure(start bool) {
+	// set mosn State Reconfiguring
 	store.SetMosnState(store.Reconfiguring)
+	// if reconfigure failed, set mosn state to Running
 	defer store.SetMosnState(store.Running)
+
+	// stop dump config file
+	store.DumpLock()
+	// if reconfigure failed, enable dump
+	defer store.DumpUnlock()
 
 	if start {
 		err := startNewMosn()
@@ -198,7 +207,19 @@ func reconfigure(start bool) {
 	}
 
 	// transfer listen fd
-	if err := sendInheritListeners(); err != nil {
+	var notify net.Conn
+	var err error
+	var n int
+	var buf [1]byte
+	if notify, err = sendInheritListeners(); err != nil {
+		return
+	}
+
+	// Wait new mosn parse configuration
+	notify.SetReadDeadline(time.Now().Add(10 * time.Minute))
+	n, err = notify.Read(buf[:])
+	if n != 1 {
+		log.DefaultLogger.Errorf("new mosn start failed")
 		return
 	}
 

--- a/pkg/server/serverkeeper.go
+++ b/pkg/server/serverkeeper.go
@@ -189,6 +189,10 @@ func startNewMosn() error {
 }
 
 func reconfigure(start bool) {
+	if start {
+		startNewMosn()
+		return
+	}
 	// set mosn State Reconfiguring
 	store.SetMosnState(store.Reconfiguring)
 	// if reconfigure failed, set mosn state to Running
@@ -198,13 +202,6 @@ func reconfigure(start bool) {
 	store.DumpLock()
 	// if reconfigure failed, enable dump
 	defer store.DumpUnlock()
-
-	if start {
-		err := startNewMosn()
-		if err != nil {
-			return
-		}
-	}
 
 	// transfer listen fd
 	var notify net.Conn

--- a/pkg/stream/http2/stream.go
+++ b/pkg/stream/http2/stream.go
@@ -194,6 +194,11 @@ func newServerStreamConnection(ctx context.Context, connection types.Connection,
 	// init first context
 	sc.cm.next()
 
+	// set not support transfer connection
+	sc.conn.SetTransferEventListener(func() bool {
+		return false
+	})
+
 	sc.streams = make(map[uint32]*serverStream, 32)
 	sc.logger.Tracef("new http2 server stream connection")
 

--- a/pkg/stream/sofarpc/stream.go
+++ b/pkg/stream/sofarpc/stream.go
@@ -115,6 +115,11 @@ func newStreamConnection(ctx context.Context, connection types.Connection, clien
 		sc.streams = make(map[uint64]*stream, 32)
 	}
 
+	// set support transfer connection
+	sc.conn.SetTransferEventListener(func() bool {
+		return true
+	})
+
 	return sc
 }
 

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -294,6 +294,9 @@ type Connection interface {
 	// Caution: raw conn only used in io-loop disable mode
 	// TODO: a better way to provide raw conn
 	RawConn() net.Conn
+
+	// SetTransferEventListener set a method will be called when connection transfer occur
+	SetTransferEventListener(listener func() bool)
 }
 
 // ConnectionStats is a group of connection metrics

--- a/test/integrate/transfer/transfer_test.go
+++ b/test/integrate/transfer/transfer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"math/rand"
+	"io/ioutil"
 
 	"github.com/alipay/sofa-mosn/pkg/log"
 	"github.com/alipay/sofa-mosn/pkg/metrics"
@@ -17,7 +18,11 @@ import (
 	_ "github.com/alipay/sofa-mosn/pkg/stream/sofarpc"
 	"github.com/alipay/sofa-mosn/test/integrate"
 	"github.com/alipay/sofa-mosn/test/util"
+	"encoding/json"
+	"github.com/alipay/sofa-mosn/pkg/config"
 )
+
+
 
 // client - mesh - mesh - server
 func forkTransferMesh(tc *integrate.TestCase) int {
@@ -39,12 +44,19 @@ func forkTransferMesh(tc *integrate.TestCase) int {
 }
 
 func startTransferMesh(tc *integrate.TestCase) {
-	rand.Seed(2)
+	rand.Seed(3)
 	server.GracefulTimeout = 5 * time.Second
 	network.TransferDomainSocket = "/tmp/mosn.sock"
 	metrics.TransferDomainSocket = "/tmp/stats.sock"
 	cfg := util.CreateMeshToMeshConfig(tc.ClientMeshAddr, tc.ServerMeshAddr, tc.AppProtocol, tc.MeshProtocol, []string{tc.AppServer.Addr()}, true)
 	cfg.Pid = "/tmp/transfer.pid"
+
+	config.ConfigPath = "/tmp/transfer.json"
+	content, err := json.MarshalIndent(cfg, "", "  ")
+	if err == nil {
+		err = ioutil.WriteFile(config.ConfigPath, content, 0644)
+	}
+
 	mesh := mosn.NewMosn(cfg)
 
 	util.MeshLogPath = ""


### PR DESCRIPTION
### Issues associated with this PR


### Sign the CLA

### Solutions
1. 新增 SetTransferEventListener, 在mosn做升级的时候, mosn通过回调函数通知协议层, 协议层可以做自己的逻辑, 然后返回是否支持链接迁移. 比如http1可以在函数里面置标, 在请求结束的时候关闭连接, 让client重新建新的请求连接.
2. 在平滑升级期间, 老的mosn暂停落盘配置.
3. service( pprof, adminApi, metric) 支持listen fd继承, 支持平滑升级期间不断服务.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
