### PR TITLE
add a new get route function

### DIFF
--- a/pkg/router/fastindex_test.go
+++ b/pkg/router/fastindex_test.go
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
+	"github.com/alipay/sofa-mosn/pkg/log"
+	"github.com/alipay/sofa-mosn/pkg/protocol"
+	"github.com/alipay/sofa-mosn/pkg/types"
+)
+
+func createRoutersCfg(cnt int) []v2.Router {
+	routersCfg := []v2.Router{}
+	for i := 0; i < cnt; i++ {
+		r := v2.Router{
+			RouterConfig: v2.RouterConfig{
+				Match: v2.RouterMatch{
+					Headers: []v2.HeaderMatcher{
+						{
+							Name:  types.SofaRouteMatchKey,
+							Value: fmt.Sprintf("service#%d", i),
+						},
+					},
+				},
+				Route: v2.RouteAction{
+					RouterActionConfig: v2.RouterActionConfig{
+						ClusterName: fmt.Sprintf("cluster#%d", i),
+					},
+				},
+			},
+		}
+		routersCfg = append(routersCfg, r)
+	}
+	return routersCfg
+}
+
+// we configured some sofa rpc routers without regex(.*)
+// without fast index, we  iterate through the slice and  find the first matching route.
+// with the fast index, we get the route directly from the key&value
+func TestFastIndexRouteFromHeaderKV(t *testing.T) {
+	routersCnt := 10
+	routersCfg := createRoutersCfg(routersCnt)
+	vhCfg := &v2.VirtualHost{
+		Domains: []string{"*"},
+		Routers: routersCfg,
+	}
+	vh, err := NewVirtualHostImpl(vhCfg, false)
+	if err != nil {
+		t.Fatal("create virtual host failed", err)
+	}
+	for i := 0; i < routersCnt; i++ {
+		value := fmt.Sprintf("service#%d", i)
+		expected := fmt.Sprintf("cluster#%d", i)
+		if route := vh.GetRouteFromHeaderKV(types.SofaRouteMatchKey, value); route == nil || route.RouteRule().ClusterName() != expected {
+			t.Errorf("#%d route match is not expected, route: %v", i, route)
+		}
+	}
+}
+
+func TestMatchRouteFromHeaderKV(t *testing.T) {
+	routersCnt := 10
+	routersCfg := createRoutersCfg(routersCnt)
+	vhCfg := &v2.VirtualHost{
+		Domains: []string{"*"},
+		Routers: routersCfg,
+	}
+	routeCfg := &v2.RouterConfiguration{
+		RouterConfigName: "test",
+		VirtualHosts: []*v2.VirtualHost{
+			vhCfg,
+		},
+	}
+	routers, err := NewRouteMatcher(routeCfg)
+	if err != nil {
+		t.Fatal("create route matcher failed")
+	}
+	for i := 0; i < routersCnt; i++ {
+		value := fmt.Sprintf("service#%d", i)
+		expected := fmt.Sprintf("cluster#%d", i)
+		// use header to find virtual host, in this case only have default virtualhost, header can be nil
+		if route := routers.MatchRouteFromHeaderKV(nil, types.SofaRouteMatchKey, value); route == nil || route.RouteRule().ClusterName() != expected {
+			t.Errorf("#%d route match is not expected, route: %v", i, route)
+		}
+	}
+
+}
+
+func BenchmarkGetSofaRouter(b *testing.B) {
+	log.DefaultLogger.SetLogLevel(log.FATAL)
+
+	routersCnt := 5000
+	routersCfg := createRoutersCfg(routersCnt)
+	vhCfg := &v2.VirtualHost{
+		Domains: []string{"*"},
+		Routers: routersCfg,
+	}
+	vh, err := NewVirtualHostImpl(vhCfg, false)
+	if err != nil {
+		b.Fatal("create virtual host failed", err)
+	}
+	value := fmt.Sprintf("service#%d", 3000)
+	expected := fmt.Sprintf("cluster#%d", 3000)
+	b.Run("kv", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if route := vh.GetRouteFromHeaderKV(types.SofaRouteMatchKey, value); route == nil || route.RouteRule().ClusterName() != expected {
+				b.Errorf("route match is not expected, route: %v", route)
+			}
+		}
+	})
+	headers := protocol.CommonHeader(map[string]string{
+		types.SofaRouteMatchKey: value,
+	})
+	b.Run("common", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if route := vh.GetRouteFromEntries(headers, 1); route == nil || route.RouteRule().ClusterName() != expected {
+				b.Errorf("route match is not expected, route: %v", route)
+			}
+		}
+	})
+}

--- a/pkg/router/handlerchain_test.go
+++ b/pkg/router/handlerchain_test.go
@@ -60,6 +60,10 @@ func (routers *mockRouters) MatchAllRoutes(headers types.HeaderMap, randomValue 
 	return nil
 }
 
+func (routers *mockRouters) MatchRouteFromHeaderKV(headers types.HeaderMap, key, value string) types.Route {
+	return nil
+}
+
 type mockManager struct {
 	types.ClusterManager
 }

--- a/pkg/router/headerformatter.go
+++ b/pkg/router/headerformatter.go
@@ -27,7 +27,7 @@ import (
 func getHeaderFormatter(value string, append bool) headerFormatter {
 	// TODO: variable headers would be support very soon
 	if strings.Index(value, "%") != -1 {
-		log.DefaultLogger.Warnf("variable headers not support yet, skip")
+		log.DefaultLogger.Warnf("variable headers not support yet, skip, value: %s", value)
 		return nil
 	}
 	return &plainHeaderFormatter{

--- a/pkg/router/routematcher.go
+++ b/pkg/router/routematcher.go
@@ -132,7 +132,7 @@ func (rm *routeMatcher) MatchRoute(headers types.HeaderMap, randomValue uint64) 
 	virtualHost := rm.findVirtualHost(headers)
 
 	if virtualHost == nil {
-		log.DefaultLogger.Infof("No VirtualHost Found when Routing, Request Headers = %+v", headers)
+		log.DefaultLogger.Debugf("No VirtualHost Found when Routing, Request Headers = %+v", headers)
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func (rm *routeMatcher) MatchRoute(headers types.HeaderMap, randomValue uint64) 
 	routerInstance := virtualHost.GetRouteFromEntries(headers, randomValue)
 
 	if routerInstance == nil {
-		log.DefaultLogger.Infof("No Router Instance Found when Routing, Request Headers = %+v", headers)
+		log.DefaultLogger.Debugf("No Router Instance Found when Routing, Request Headers = %+v", headers)
 	}
 
 	return routerInstance
@@ -151,14 +151,28 @@ func (rm *routeMatcher) MatchAllRoutes(headers types.HeaderMap, randomValue uint
 	log.StartLogger.Tracef("routing header = %v,randomValue=%v", headers, randomValue)
 	virtualHost := rm.findVirtualHost(headers)
 	if virtualHost == nil {
-		log.DefaultLogger.Infof("No VirtualHost Found when Routing, Request Headers = %+v", headers)
+		log.DefaultLogger.Debugf("No VirtualHost Found when Routing, Request Headers = %+v", headers)
 		return nil
 	}
 	routers := virtualHost.GetAllRoutesFromEntries(headers, randomValue)
 	if routers == nil {
-		log.DefaultLogger.Infof("No Router Instance Found when Routing, Request Headers = %+v", headers)
+		log.DefaultLogger.Debugf("No Router Instance Found when Routing, Request Headers = %+v", headers)
 	}
 	return routers
+}
+
+func (rm *routeMatcher) MatchRouteFromHeaderKV(headers types.HeaderMap, key string, value string) types.Route {
+	log.StartLogger.Tracef("fast index header, key=%s, value=%s", key, value)
+	virtualHost := rm.findVirtualHost(headers)
+	if virtualHost == nil {
+		log.DefaultLogger.Debugf("No VirtualHost Found when Routing, Request Headers = %+v", headers)
+		return nil
+	}
+	routerInstance := virtualHost.GetRouteFromHeaderKV(key, value)
+	if routerInstance == nil {
+		log.DefaultLogger.Debugf("No Router Instance Found when Routing, Request Headers = %+v", headers)
+	}
+	return routerInstance
 }
 
 func (rm *routeMatcher) findVirtualHost(headers types.HeaderMap) types.VirtualHost {

--- a/pkg/router/routersmanager.go
+++ b/pkg/router/routersmanager.go
@@ -91,16 +91,16 @@ func (rm *routersManager) AddOrUpdateRouters(routerConfig *v2.RouterConfiguratio
 	if v, ok := rm.routersMap.Load(routerConfig.RouterConfigName); ok {
 		// try to update router
 		if primaryRouters, ok := v.(*RoutersWrapper); ok {
-			primaryRouters.mux.Lock()
-			defer primaryRouters.mux.Unlock()
 			routers, err := NewRouteMatcher(routerConfig)
 			if err != nil {
 				log.DefaultLogger.Errorf("AddOrUpdateRouters, update router:%s error: %v", routerConfig.RouterConfigName, err)
 				return err
 			}
 			log.DefaultLogger.Debugf("AddOrUpdateRouters, update router:%s success", routerConfig.RouterConfigName)
+			primaryRouters.mux.Lock()
 			primaryRouters.routers = routers
 			primaryRouters.routersConfig = routerConfig
+			primaryRouters.mux.Unlock()
 		}
 	} else {
 		// try to create a new router

--- a/pkg/types/route.go
+++ b/pkg/types/route.go
@@ -45,6 +45,9 @@ type Routers interface {
 	MatchRoute(headers HeaderMap, randomValue uint64) Route
 	// MatchAllRoutes returns all routes with headers
 	MatchAllRoutes(headers HeaderMap, randomValue uint64) []Route
+	// MatchRouteFromHeaderKV is used to quickly locate and obtain routes in certain scenarios
+	// header is used to find virtual host
+	MatchRouteFromHeaderKV(headers HeaderMap, key, value string) Route
 }
 
 // RouterManager is a manager for all routers' config
@@ -260,6 +263,8 @@ type VirtualHost interface {
 	GetRouteFromEntries(headers HeaderMap, randomValue uint64) Route
 	// GetAllRoutesFromEntries returns all Route matched the condition
 	GetAllRoutesFromEntries(headers HeaderMap, randomValue uint64) []Route
+	// GetRouteFromHeaderKV is used to quickly locate and obtain routes in certain scenarios
+	GetRouteFromHeaderKV(key, value string) Route
 }
 
 type RedirectRule interface {


### PR DESCRIPTION
增加使用Header的Key-Value快速获取Route的方法。
在一些特定的场景下，只需要通过特定的Key-Value来获取路由信息。
如果明确MOSN使用时有类似的场景，可以在RouteChain的处理过程中使用该方法代替MatchRoute的遍历方法。
性能测试对比：
有5000个Route的情况下，选择第3000个配置，kv（新方法）和common（MatchRoute）对比
BenchmarkGetSofaRouter/kv-4         	50000000	        31.9 ns/op
BenchmarkGetSofaRouter/common-4     	   10000	    201131 ns/op