### PR TITLE
load balancer type can be registered

### DIFF
--- a/pkg/types/loadbalancer.go
+++ b/pkg/types/loadbalancer.go
@@ -26,8 +26,8 @@ type LoadBalancerType string
 
 // The load balancer's types
 const (
-	RoundRobin LoadBalancerType = "RoundRobin"
-	Random     LoadBalancerType = "Random"
+	RoundRobin LoadBalancerType = "LB_ROUNDROBIN"
+	Random     LoadBalancerType = "LB_RANDOM"
 )
 
 // LoadBalancer is a upstream load balancer.

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -79,6 +79,9 @@ func newCluster(clusterConfig v2.Cluster, sourceAddr net.Addr, addedViaAPI bool,
 
 	case v2.LB_ROUNDROBIN:
 		cluster.info.lbType = types.RoundRobin
+	default:
+		// default used for registered lb type
+		cluster.info.lbType = types.LoadBalancerType(clusterConfig.LbType)
 	}
 
 	// TODO: init more props: maxrequestsperconn, connecttimeout, connectionbuflimit

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -73,16 +73,8 @@ func newCluster(clusterConfig v2.Cluster, sourceAddr net.Addr, addedViaAPI bool,
 		initHelper: initHelper,
 	}
 
-	switch clusterConfig.LbType {
-	case v2.LB_RANDOM:
-		cluster.info.lbType = types.Random
-
-	case v2.LB_ROUNDROBIN:
-		cluster.info.lbType = types.RoundRobin
-	default:
-		// default used for registered lb type
-		cluster.info.lbType = types.LoadBalancerType(clusterConfig.LbType)
-	}
+	// compatible, types.LoadBalancerType is same as v2.LbType
+	cluster.info.lbType = types.LoadBalancerType(clusterConfig.LbType)
 
 	// TODO: init more props: maxrequestsperconn, connecttimeout, connectionbuflimit
 

--- a/pkg/upstream/cluster/cluster.go
+++ b/pkg/upstream/cluster/cluster.go
@@ -273,6 +273,10 @@ type prioritySet struct {
 	mux             sync.RWMutex
 }
 
+func NewPrioritySet() types.PrioritySet {
+	return &prioritySet{}
+}
+
 func (ps *prioritySet) GetOrCreateHostSet(priority uint32) types.HostSet {
 	ps.mux.Lock()
 	defer ps.mux.Unlock()

--- a/pkg/upstream/cluster/lb_register_test.go
+++ b/pkg/upstream/cluster/lb_register_test.go
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/protocol"
+	"github.com/alipay/sofa-mosn/pkg/types"
+)
+
+type headerLB struct {
+	prioritySet types.PrioritySet // store the hosts
+	key         string
+	randLB      types.LoadBalancer
+}
+
+// header lb choose host from header's key, if not exists, random return one
+func (lb *headerLB) ChooseHost(ctx types.LoadBalancerContext) types.Host {
+	if headers := ctx.DownstreamHeaders(); headers != nil {
+		if value, ok := headers.Get(lb.key); ok {
+			hosts := lb.prioritySet.GetOrCreateHostSet(0).HealthyHosts()
+			for _, h := range hosts {
+				if h.Hostname() == value {
+					return h
+				}
+			}
+		}
+	}
+	// random choose a host
+	return lb.randLB.ChooseHost(ctx)
+}
+
+type headerLBCfg struct {
+	key string
+}
+
+func (cfg *headerLBCfg) newLB(ps types.PrioritySet) types.LoadBalancer {
+	return &headerLB{
+		prioritySet: ps,
+		key:         cfg.key,
+		randLB:      newRandomLoadbalancer(ps),
+	}
+}
+
+const headerKey types.LoadBalancerType = "HeaderKey"
+
+// Test Registered new load balancer
+// subset load balancer is valid too.
+func TestRegisterNewLB(t *testing.T) {
+	cfg := &headerLBCfg{
+		key: "hostname",
+	}
+	RegisterLBType(headerKey, cfg.newLB)
+	// init hosts
+	// reuse subset test config
+	ps := createPrioritySet(ExampleHostConfigs())
+	lb := NewLoadBalancer(headerKey, ps)
+	// expected headerLB
+	if _, ok := lb.(*headerLB); !ok {
+		t.Fatal("load balancer created not expected")
+	}
+	ctx := newMockLbContextWithHeader(map[string]string{
+		"version": "1.0",
+	}, protocol.CommonHeader(map[string]string{
+		"hostname": "e1",
+	}))
+	ctx2 := newMockLbContext(map[string]string{
+		"version": "1.0",
+	})
+	// subset info is useless
+	for i := 0; i < 100; i++ {
+		host := lb.ChooseHost(ctx)
+		if host == nil || host.Hostname() != "e1" {
+			t.Fatal("choose host not expected, get: ", host)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		host := lb.ChooseHost(ctx2)
+		if host == nil {
+			t.Fatal("choose host failed")
+		}
+	}
+
+	// subset is also valid
+	//  reuse subset test config
+	subsetInfo := NewLBSubsetInfo(ExampleSubsetConfig())
+	sublb := NewSubsetLoadBalancer(headerKey, ps, newClusterStats("test"), subsetInfo)
+	// choose host is valid
+	// 1. ctx contains subset matched config
+	// 2. ctx contains header with key "hostname"
+	// should choose e1 only
+	for i := 0; i < 100; i++ {
+		host := sublb.ChooseHost(ctx)
+		if host == nil || host.Hostname() != "e1" {
+			t.Fatal("choose host not expected, get: ", host)
+		}
+	}
+	// choose e1,e2,e5
+	for i := 0; i < 100; i++ {
+		host := sublb.ChooseHost(ctx2)
+		if host == nil {
+			t.Fatal("choose host failed")
+		}
+		switch host.Hostname() {
+		case "e1", "e2", "e5":
+		default:
+			t.Fatal("choose host not expected, get: ", host)
+		}
+	}
+}

--- a/pkg/upstream/cluster/lb_register_test.go
+++ b/pkg/upstream/cluster/lb_register_test.go
@@ -20,6 +20,7 @@ package cluster
 import (
 	"testing"
 
+	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/protocol"
 	"github.com/alipay/sofa-mosn/pkg/types"
 )
@@ -122,5 +123,21 @@ func TestRegisterNewLB(t *testing.T) {
 		default:
 			t.Fatal("choose host not expected, get: ", host)
 		}
+	}
+}
+
+// Test Used in cluster
+func TestNewLBCluster(t *testing.T) {
+	cfg := v2.Cluster{
+		Name:        "test",
+		ClusterType: v2.SIMPLE_CLUSTER,
+		LbType:      v2.LbType(headerKey), // same as lb type
+	}
+	c := newCluster(cfg, nil, true, nil)
+	if c == nil || c.Info() == nil {
+		t.Fatal("create cluster failed")
+	}
+	if c.Info().LbType() != headerKey {
+		t.Fatal("create cluster lb type not expected")
 	}
 }

--- a/pkg/upstream/cluster/loadbalancer.go
+++ b/pkg/upstream/cluster/loadbalancer.go
@@ -30,13 +30,14 @@ import (
 var lbFactories map[types.LoadBalancerType]func(types.PrioritySet) types.LoadBalancer
 
 func init() {
-	lbFactories = map[types.LoadBalancerType]func(types.PrioritySet) types.LoadBalancer{
-		types.RoundRobin: newSmoothWeightedRRLoadBalancer,
-		types.Random:     newRandomLoadbalancer,
-	}
+	RegisterLBType(types.RoundRobin, newSmoothWeightedRRLoadBalancer)
+	RegisterLBType(types.Random, newRandomLoadbalancer)
 }
 
 func RegisterLBType(lbType types.LoadBalancerType, f func(types.PrioritySet) types.LoadBalancer) {
+	if lbFactories == nil {
+		lbFactories = make(map[types.LoadBalancerType]func(types.PrioritySet) types.LoadBalancer)
+	}
 	lbFactories[lbType] = f
 }
 

--- a/pkg/upstream/cluster/subsetlbimpl_test.go
+++ b/pkg/upstream/cluster/subsetlbimpl_test.go
@@ -812,7 +812,8 @@ func TestGetFinalHost(t *testing.T) {
 // utils for test
 type mockLbContext struct {
 	types.LoadBalancerContext
-	mmc types.MetadataMatchCriteria
+	mmc    types.MetadataMatchCriteria
+	header types.HeaderMap
 }
 
 func newMockLbContext(m map[string]string) types.LoadBalancerContext {
@@ -822,6 +823,18 @@ func newMockLbContext(m map[string]string) types.LoadBalancerContext {
 	}
 }
 
+func newMockLbContextWithHeader(m map[string]string, header types.HeaderMap) types.LoadBalancerContext {
+	mmc := router.NewMetadataMatchCriteriaImpl(m)
+	return &mockLbContext{
+		mmc:    mmc,
+		header: header,
+	}
+}
+
 func (ctx *mockLbContext) MetadataMatchCriteria() types.MetadataMatchCriteria {
 	return ctx.mmc
+}
+
+func (ctx *mockLbContext) DownstreamHeaders() types.HeaderMap {
+	return ctx.header
 }


### PR DESCRIPTION
+ LB的类型可以扩展，通过注册的方式增加扩展类型
+ 增加prioritySet的可导出New方法，实现扩展的时候可以用于补充测试
+ subset lb的生成逻辑可以复用，根据metadata选择出最终的LB也可以是扩展类型 （subset不是LBType）
