### PR TITLE
fix sofa bolt timeout

### DIFF
--- a/pkg/protocol/rpc/sofarpc/codec/codec_test.go
+++ b/pkg/protocol/rpc/sofarpc/codec/codec_test.go
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/alipay/sofa-mosn/pkg/protocol/rpc/sofarpc"
+)
+
+// compare binary put and get
+func TestBinary(t *testing.T) {
+	var timeout int = -1
+	// encode
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, uint32(timeout))
+	// decode
+	data := binary.BigEndian.Uint32(b)
+	// signed to unsigned, overflow
+	const maxOverFlow int = 4294967295
+	if int(data) != maxOverFlow {
+		t.Errorf("expected overflow")
+	}
+	// new decode, keeps the signed
+	var newData int32
+	buf := bytes.NewReader(b)
+	binary.Read(buf, binary.BigEndian, &newData)
+	if int(newData) != timeout {
+		t.Errorf("expected keep the signed int")
+	}
+
+}
+
+func TestDecodeAndEncode_BoltV1(t *testing.T) {
+	req := &sofarpc.BoltRequest{
+		Protocol: sofarpc.PROTOCOL_CODE_V1,
+		CmdType:  sofarpc.REQUEST,
+		CmdCode:  sofarpc.RPC_REQUEST,
+		Version:  1,
+		ReqID:    1,
+		Codec:    sofarpc.HESSIAN2_SERIALIZE, //todo: read default codec from config
+		Timeout:  -1,
+	}
+	ctx := context.Background()
+	buffer, err := BoltCodec.Encode(ctx, req)
+	if err != nil {
+		t.Fatal("Encode bolt v1 request failed", err)
+	}
+	ctx1 := context.Background()
+	v, err := BoltCodec.Decode(ctx1, buffer)
+	if err != nil {
+		t.Fatal("Decode bolt v1 data failed", err)
+	}
+	req1, ok := v.(*sofarpc.BoltRequest)
+	if !ok {
+		t.Fatal("Decode bolt v1 request failed")
+	}
+	// verify
+	// just verify timeout now
+	if req.Timeout != req1.Timeout {
+		t.Errorf("decode request is not equal origin request, origin: %d, got: %d", req.Timeout, req1.Timeout)
+	}
+}
+
+func TestDecodeAndEncode_BoltV2(t *testing.T) {
+	// just a request data for unit test
+	// may be it is a invalid boltv2 request
+	req := &sofarpc.BoltRequestV2{
+		BoltRequest: sofarpc.BoltRequest{
+			Protocol: sofarpc.PROTOCOL_CODE_V2,
+			CmdType:  sofarpc.REQUEST,
+			CmdCode:  sofarpc.RPC_REQUEST,
+			Version:  0x02,
+			ReqID:    1,
+			Codec:    sofarpc.HESSIAN2_SERIALIZE,
+			Timeout:  -1,
+		},
+		Version1:   0x01,
+		SwitchCode: 0x00,
+	}
+	ctx := context.Background()
+	buffer, err := BoltCodecV2.Encode(ctx, req)
+	if err != nil {
+		t.Fatal("Encode bolt v2 request failed", err)
+	}
+	ctx1 := context.Background()
+	v, err := BoltCodecV2.Decode(ctx1, buffer)
+	if err != nil {
+		t.Fatal("Decode bolt v2 data failed", err)
+	}
+	req1, ok := v.(*sofarpc.BoltRequestV2)
+	if !ok {
+		t.Fatal("Decode bolt v2 request failed")
+	}
+	// verify
+	// just verify timeout now
+	if req.Timeout != req1.Timeout {
+		t.Errorf("decode request is not equal origin request, origin: %d, got: %d", req.Timeout, req1.Timeout)
+	}
+}

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -514,6 +514,7 @@ func (s *downStream) onUpstreamRequestSent() {
 
 		// setup global timeout timer
 		if s.timeout.GlobalTimeout > 0 {
+			log.DefaultLogger.Debugf("start a request timeout timer")
 			if s.responseTimer != nil {
 				s.responseTimer.Stop()
 			}

--- a/pkg/stream/sofarpc/stream.go
+++ b/pkg/stream/sofarpc/stream.go
@@ -216,12 +216,7 @@ func (conn *streamConnection) handleCommand(ctx context.Context, model interface
 	if stream != nil {
 		data := cmd.Data()
 
-		// sofa rpc set timeout -1 means no timeout
-		// if we got -1 timeout, we should set it to 0, ignore the config
 		timeoutInt := cmd.GetTimeout()
-		if timeoutInt == -1 {
-			timeoutInt = 0
-		}
 		timeout := strconv.Itoa(timeoutInt) // timeout, ms
 		cmd.Set(types.HeaderGlobalTimeout, timeout)
 

--- a/pkg/stream/sofarpc/stream.go
+++ b/pkg/stream/sofarpc/stream.go
@@ -216,10 +216,14 @@ func (conn *streamConnection) handleCommand(ctx context.Context, model interface
 	if stream != nil {
 		data := cmd.Data()
 
-		if cmd.GetTimeout() > 0 {
-			timeout := strconv.Itoa(cmd.GetTimeout()) // timeout, ms
-			cmd.Set(types.HeaderGlobalTimeout, timeout)
+		// sofa rpc set timeout -1 means no timeout
+		// if we got -1 timeout, we should set it to 0, ignore the config
+		timeoutInt := cmd.GetTimeout()
+		if timeoutInt == -1 {
+			timeoutInt = 0
 		}
+		timeout := strconv.Itoa(timeoutInt) // timeout, ms
+		cmd.Set(types.HeaderGlobalTimeout, timeout)
 
 		stream.receiver.OnReceiveHeaders(stream.ctx, cmd, data == nil)
 


### PR DESCRIPTION
1. BOLT协议中 如果Timeout为-1，应该是不希望有超时。此时即便MOSN配置了超时，也应该以协议中的为准。MOSN中，如果Timeout被配置成了-1，必然不会大于0，因此不会开启timeout的timer。
但是如果Header中不设置，则会以MOSN配置为准，这里不符合预期

2. 在BOLT协议中Timeout字段为int，是有符号的整数，但是原来解析的逻辑中，通过binary库处理以后，符号丢失，导致-1会溢出为4294967295 (UT中补充了一个测试进行说明），需要使用新的方法来“保持”符号
