### PR TITLE
fix activeStreamSenderFilter SetResponsexxx invalid

### DIFF
--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -425,9 +425,6 @@ func (s *downStream) receive(ctx context.Context, id uint32, phase types.Phase) 
 		s.logger.Tracef("downstream OnReceive send downstream response %+v", s.downstreamRespHeaders)
 
 		upstreamRequest = s.upstreamRequest
-		respHeaders = s.downstreamRespHeaders
-		respData = s.downstreamRespDataBuf
-		respTrailers = s.downstreamRespTrailers
 		phase++
 		fallthrough
 
@@ -437,6 +434,10 @@ func (s *downStream) receive(ctx context.Context, id uint32, phase types.Phase) 
 		if s.runAppendFilters(phase, respHeaders, respData, respTrailers) {
 			return types.End
 		}
+
+		respHeaders = s.downstreamRespHeaders
+		respData = s.downstreamRespDataBuf
+		respTrailers = s.downstreamRespTrailers
 
 		if p, err := s.processError(id); err != nil {
 			return p

--- a/pkg/proxy/streamfilters_test.go
+++ b/pkg/proxy/streamfilters_test.go
@@ -228,10 +228,11 @@ func TestRunSenderFiltersStop(t *testing.T) {
 		s.AddStreamSenderFilter(f)
 	}
 	// mock run
-	s.downstreamRespDataBuf = buffer.NewIoBuffer(0)
-	s.downstreamRespTrailers = protocol.CommonHeader{}
 
-	s.runAppendFilters(0, nil, s.downstreamRespDataBuf, s.downstreamReqTrailers)
+	s.runAppendFilters(0, nil, nil, nil)
+	if s.downstreamRespHeaders == nil || s.downstreamRespDataBuf == nil {
+		t.Errorf("streamSendFilter SetResponse error")
+	}
 
 	if tc.filters[0].on != 1 || tc.filters[1].on != 1 || tc.filters[2].on != 0 {
 		t.Errorf("streamSendFilter is error")
@@ -270,6 +271,8 @@ func (f *mockStreamSenderFilter) OnDestroy() {}
 
 func (f *mockStreamSenderFilter) Append(ctx context.Context, headers types.HeaderMap, buf types.IoBuffer, trailers types.HeaderMap) types.StreamFilterStatus {
 	f.on++
+	f.handler.SetResponseHeaders(protocol.CommonHeader{})
+	f.handler.SetResponseData(buffer.NewIoBuffer(1))
 	return f.status
 }
 

--- a/pkg/proxy/upstream.go
+++ b/pkg/proxy/upstream.go
@@ -112,7 +112,7 @@ func (r *upstreamRequest) endStream() {
 }
 
 func (r *upstreamRequest) OnReceive(ctx context.Context, headers types.HeaderMap, data types.IoBuffer, trailers types.HeaderMap) {
-	if r.downStream.processDone() {
+	if r.downStream.processDone()  || r.setupRetry {
 		return
 	}
 


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
当在activeStreamSenderFilter设置header和data时, 会导致设置无效.


### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
