### PR TITLE
fix panic caused by metric name exceed

### DIFF
--- a/pkg/metrics/shm/entry.go
+++ b/pkg/metrics/shm/entry.go
@@ -21,15 +21,15 @@ import (
 	"sync/atomic"
 )
 
-const maxNameLength = 100
+const maxNameLength = 107
 
 // metricsEntry is the mapping for metrics entry record memory-layout in shared memory.
 //
 // This struct should never be instantiated.
 type metricsEntry struct {
-	value int64     // 8
-	ref   uint32    // 4
-	name  [maxNameLength]byte // 100
+	value int64                   // 8
+	ref   uint32                  // 4
+	name  [maxNameLength + 1]byte // 100 + 1 for '\0', end of string tag in C-style string
 }
 
 func (e *metricsEntry) assignName(name []byte) {

--- a/pkg/metrics/shm/entry.go
+++ b/pkg/metrics/shm/entry.go
@@ -29,7 +29,7 @@ const maxNameLength = 107
 type metricsEntry struct {
 	value int64                   // 8
 	ref   uint32                  // 4
-	name  [maxNameLength + 1]byte // 100 + 1 for '\0', end of string tag in C-style string
+	name  [maxNameLength + 1]byte // 107 + 1 for '\0', end of string tag in C-style string
 }
 
 func (e *metricsEntry) assignName(name []byte) {

--- a/pkg/metrics/shm/hashset_test.go
+++ b/pkg/metrics/shm/hashset_test.go
@@ -20,6 +20,8 @@ package shm
 import (
 	"strconv"
 	"testing"
+	"unsafe"
+	"math/rand"
 )
 
 func TestHashSet_Alloc(t *testing.T) {
@@ -79,6 +81,31 @@ func TestHashSet_Free(t *testing.T) {
 	if entry != realloc {
 		t.Error("free and reuse not expected")
 	}
+
+}
+
+func TestHashSet_EntrySize(t *testing.T) {
+	if sz := unsafe.Sizeof(hashEntry{}); sz != 128 {
+		t.Error("hash entry size mismatch:", sz)
+	}
+}
+
+func TestHashSet_AddWithLongName(t *testing.T) {
+	zone := InitMetricsZone("TestHashSet_AddWithLongName", 10*1024)
+	defer func() {
+		zone.Detach()
+		Reset()
+	}()
+
+	const charset = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	length := 200
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	defaultZone.alloc(string(b))
 
 }
 

--- a/pkg/metrics/shm/hashset_test.go
+++ b/pkg/metrics/shm/hashset_test.go
@@ -106,7 +106,24 @@ func TestHashSet_AddWithLongName(t *testing.T) {
 		b[i] = charset[rand.Intn(len(charset))]
 	}
 	defaultZone.alloc(string(b))
+}
 
+func TestHashSet_AddWithMaxLengthName(t *testing.T) {
+	zone := InitMetricsZone("TestHashSet_AddWithMaxLengthName", 10*1024)
+	defer func() {
+		zone.Detach()
+		Reset()
+	}()
+
+	const charset = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	length := maxNameLength
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	defaultZone.alloc(string(b))
 }
 
 func BenchmarkHashSet_Free(b *testing.B) {


### PR DESCRIPTION
- fix the name array size problem.(missing space for '\0')
- truncate the metric name if it exceeded the maxNameLength. We use FNV-1A hash string value as leading character to ensure the unique of truncated name.