### PR TITLE
Disable accesslog

### DIFF
--- a/pkg/config/dumper.go
+++ b/pkg/config/dumper.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	gojson "encoding/json"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -114,8 +115,8 @@ func DumpConfig() {
 
 		//update mosn_config
 		store.SetMOSNConfig(config)
-		//todo: ignore zero values in config struct @boqin
-		content, err := json.MarshalIndent(config, "", "  ")
+		// use golang original json lib, so the marshal ident can handle MarshalJSON interface implement correctly
+		content, err := gojson.MarshalIndent(config, "", "  ")
 		if err == nil {
 			err = v2.WriteFileSafety(configPath, content, 0644)
 		}


### PR DESCRIPTION
+ 添加一个默认AccessLog的开关，如果设置为关，默认不会写AccessLog（降级）
   + 与不配置AccessLog相比，默认关闭以后，可以直接通过ADMIN API开启AccessLog
+ json-iterator的JSON MarshalIdent实现存在问题，无法正确识别MarshalJSON自定义后的场景，改用Go自带的JSON LIB来做MarshalIdent