### PR TITLE
use std json to marshal config, makes the config more readable

### DIFF
--- a/pkg/api/v2/unmarshal.go
+++ b/pkg/api/v2/unmarshal.go
@@ -247,7 +247,7 @@ func (rc RouterConfiguration) MarshalJSON() (b []byte, err error) {
 		if fileName == "" {
 			fileName = fmt.Sprintf("%d", time.Now().UnixNano())
 		}
-		data, err := json.Marshal(vh)
+		data, err := json.MarshalIndent(vh, "", " ")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -120,7 +121,7 @@ func (cc ClusterManagerConfig) MarshalJSON() (b []byte, err error) {
 		if fileName == "" {
 			fileName = fmt.Sprintf("%d", time.Now().UnixNano())
 		}
-		data, err := json.Marshal(cluster)
+		data, err := json.MarshalIndent(cluster, "", " ")
 		if err != nil {
 			return nil, err
 		}
@@ -150,7 +151,7 @@ type MOSNConfig struct {
 	Metrics             MetricsConfig       `json:"metrics"`
 	RawDynamicResources jsoniter.RawMessage `json:"dynamic_resources,omitempty"` //dynamic_resources raw message
 	RawStaticResources  jsoniter.RawMessage `json:"static_resources,omitempty"`  //static_resources raw message
-	RawAdmin            jsoniter.RawMessage `json:"admin,omitempty"`             // admin raw message
+	RawAdmin            json.RawMessage     `json:"admin,omitempty"`             // admin raw message
 	Debug               PProfConfig         `json:"pprof,omitempty"`
 	Pid                 string              `json:"pid,omitempty"` // pid file
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/c2h5oh/datasize"
 	xdsboot "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/json-iterator/go"
 )
 
 type ContentKey string
@@ -147,13 +146,13 @@ type MOSNConfig struct {
 	ClusterManager  ClusterManagerConfig   `json:"cluster_manager,omitempty"` //cluster config
 	ServiceRegistry v2.ServiceRegistryInfo `json:"service_registry"`          //service registry config, used by service discovery module
 	//tracing config
-	Tracing             TracingConfig       `json:"tracing"`
-	Metrics             MetricsConfig       `json:"metrics"`
-	RawDynamicResources jsoniter.RawMessage `json:"dynamic_resources,omitempty"` //dynamic_resources raw message
-	RawStaticResources  jsoniter.RawMessage `json:"static_resources,omitempty"`  //static_resources raw message
-	RawAdmin            json.RawMessage     `json:"admin,omitempty"`             // admin raw message
-	Debug               PProfConfig         `json:"pprof,omitempty"`
-	Pid                 string              `json:"pid,omitempty"` // pid file
+	Tracing             TracingConfig   `json:"tracing"`
+	Metrics             MetricsConfig   `json:"metrics"`
+	RawDynamicResources json.RawMessage `json:"dynamic_resources,omitempty"` //dynamic_resources raw message
+	RawStaticResources  json.RawMessage `json:"static_resources,omitempty"`  //static_resources raw message
+	RawAdmin            json.RawMessage `json:"admin,omitempty"`             // admin raw message
+	Debug               PProfConfig     `json:"pprof,omitempty"`
+	Pid                 string          `json:"pid,omitempty"` // pid file
 }
 
 // PProfConfig is used to start a pprof server for debug

--- a/pkg/config/configmanager_test.go
+++ b/pkg/config/configmanager_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 

--- a/pkg/config/data_test.go
+++ b/pkg/config/data_test.go
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+const cfgStr = `{
+	 "servers": [
+	 	{
+			"mosn_server_name": "test_mosn_server",
+			"listeners": [
+				{
+					 "name": "test_mosn_listener",
+					 "address": "127.0.0.1:8080",
+					 "filter_chains": [
+					 	{
+							"filters": [
+								{
+									 "type": "proxy",
+									 "config": {
+										 "downstream_protocol": "SofaRpc",
+										 "upstream_protocol": "SofaRpc",
+										 "router_config_name": "test_router"
+									 }
+								},
+								{
+									 "type": "connection_manager",
+									 "config": {
+										 "router_config_name": "test_router",
+										 "router_configs": "/tmp/routers/test_router/"
+									 }
+								}
+							]
+						}
+					 ],
+					 "stream_filters": [
+					 ]
+				}
+			]
+		}
+	 ],
+	 "cluster_manager": {
+		 "clusters_configs": "/tmp/clusters"
+	 },
+	 "admin": {
+		 "address": {
+			 "socket_address": {
+				 "address": "0.0.0.0",
+				 "port_value": 34901
+			 }
+		 }
+	 }
+}`

--- a/pkg/config/dumper.go
+++ b/pkg/config/dumper.go
@@ -18,7 +18,7 @@
 package config
 
 import (
-	gojson "encoding/json"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -79,7 +79,7 @@ func dumpRouterConfig() bool {
 			}
 		}
 
-		if data, err := json.Marshal(routerConfig); err == nil {
+		if data, err := json.MarshalIndent(routerConfig, "", " "); err == nil {
 			cfg := make(map[string]interface{})
 			if err := json.Unmarshal(data, &cfg); err != nil {
 				log.DefaultLogger.Errorf("invalid router config, update config failed")
@@ -117,7 +117,7 @@ func DumpConfig() {
 		//update mosn_config
 		store.SetMOSNConfig(config)
 		// use golang original json lib, so the marshal ident can handle MarshalJSON interface implement correctly
-		content, err := gojson.MarshalIndent(config, "", "  ")
+		content, err := json.MarshalIndent(config, "", "  ")
 		if err == nil {
 			err = utils.WriteFileSafety(configPath, content, 0644)
 		}

--- a/pkg/config/load_config.go
+++ b/pkg/config/load_config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"log"
 	"path/filepath"

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -18,13 +18,13 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
-
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/alipay/sofa-mosn/pkg/api/v2"
 	"github.com/alipay/sofa-mosn/pkg/filter"
@@ -32,10 +32,7 @@ import (
 	"github.com/alipay/sofa-mosn/pkg/protocol"
 	"github.com/alipay/sofa-mosn/pkg/types"
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/json-iterator/go"
 )
-
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 var protocolsSupported = map[string]bool{
 	string(protocol.Auto):      true,

--- a/pkg/config/parser_test.go
+++ b/pkg/config/parser_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"encoding/json"
 	"net"
 	"reflect"
 	"testing"
@@ -108,7 +109,7 @@ var mockedFilterChains = `
                                 {
                                   "cluster":{
                                     "name":"serverCluster1",
-                                    "weight":90,m
+                                    "weight":90,
                                     "metadata_match":{
                                       "filter_metadata": {
                                         "mosn.lb": {
@@ -145,25 +146,15 @@ var mockedFilterChains = `
 func TestParseRouterConfiguration(t *testing.T) {
 	bytes := []byte(mockedFilterChains)
 	filterChan := &v2.FilterChain{}
-	json.Unmarshal(bytes, filterChan)
+	if err := json.Unmarshal(bytes, filterChan); err != nil {
+		t.Fatalf("init router config failed: %v", err)
+	}
 
 	routerCfg := ParseRouterConfiguration(filterChan)
 
 	if routerCfg.RouterConfigName != "test_router" || len(routerCfg.VirtualHosts) != 1 ||
 		routerCfg.VirtualHosts[0].Name != "sofa" || len(routerCfg.VirtualHosts[0].Routers) != 1 {
-		t.Errorf("TestParseRouterConfiguration error")
-	}
-}
-
-func TestGetListenerDisableIO(t *testing.T) {
-	bytes := []byte(mockedFilterChains)
-	filterChan := &v2.FilterChain{}
-	json.Unmarshal(bytes, filterChan)
-
-	wanted := false
-
-	if disableIO := GetListenerDisableIO(filterChan); disableIO != wanted {
-		t.Errorf("TestGetListenerDisableIO error, want %t but got %t ", disableIO, wanted)
+		t.Errorf("TestParseRouterConfiguration error, config: %v", routerCfg)
 	}
 }
 

--- a/test/integrate/functiontest/faultinject_test.go
+++ b/test/integrate/functiontest/faultinject_test.go
@@ -2,6 +2,7 @@ package functiontest
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -18,11 +19,8 @@ import (
 	_ "github.com/alipay/sofa-mosn/pkg/stream/sofarpc"
 	"github.com/alipay/sofa-mosn/test/integrate"
 	"github.com/alipay/sofa-mosn/test/util"
-	"github.com/json-iterator/go"
 	"golang.org/x/net/http2"
 )
-
-var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func AddFaultInject(mosn *config.MOSNConfig, listenername string, faultstr string) error {
 	// make v2 config

--- a/test/integrate/functiontest/tls_update_test.go
+++ b/test/integrate/functiontest/tls_update_test.go
@@ -3,6 +3,7 @@ package functiontest
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -25,7 +26,6 @@ import (
 	_ "github.com/alipay/sofa-mosn/pkg/stream/xprotocol"
 	"github.com/alipay/sofa-mosn/pkg/types"
 	"github.com/alipay/sofa-mosn/test/util"
-	"github.com/json-iterator/go"
 	"golang.org/x/net/http2"
 )
 
@@ -115,7 +115,7 @@ func MakeProxyWithTLSConfig(listenerName string, addr string, hosts []string, pr
 	lnCfg := util.NewListener(listenerName, addr, chains)
 	lnCfg.Inspector = false
 	mosnConfig := util.NewMOSNConfig([]v2.Listener{lnCfg}, cmconfig)
-	mosnConfig.RawAdmin = jsoniter.RawMessage([]byte(`{
+	mosnConfig.RawAdmin = json.RawMessage([]byte(`{
 		 "address":{
 			 "socket_address":{
 				 "address": "127.0.0.1",


### PR DESCRIPTION
1. Cluster和Router作为动态模式，解析到文件的时候，默认使用Ident，增加可读性
2. Ident只有在标准库下工作正常，对于配置解析，性能稍微差点是可以接受的
    + Unmarshal在启动时执行有限次
    + Marshal在DUMP时执行一次，DUMP每隔几秒才执行一次

性能测试对比，在5k个Cluster的场景下（可能会写5K个文件）
BenchmarkConfigUnmarshal/json-iterator_testing-4         	      10	 147068262 ns/op
BenchmarkConfigUnmarshal/std_json_testing-4              	      10	 146789075 ns/op
BenchmarkConfigMarshal/json-iterator_testing-4           	       1	1216239251 ns/op
BenchmarkConfigMarshal/std_json_testing-4                	       1	1329165485 ns/op