### PR TITLE
keepalive without goroutine

### DIFF
--- a/examples/codes/sofarpc-sample/config.json
+++ b/examples/codes/sofarpc-sample/config.json
@@ -37,7 +37,19 @@
 
 					 
 			 }]
-	    }]
+	    }],
+	    "stream_filters": [
+	    	{
+			"type": "healthcheck",
+			"config": {
+				"cache_time": "360s",
+				"cluster_min_healthy_percentages": {
+					"local_service": 70
+				},
+				"passthrough": false
+			}
+		}
+	    ]
 	  },
 	  {
 	    "name":"clientListener",

--- a/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
+++ b/pkg/filter/stream/healthcheck/sofarpc/healthcheck.go
@@ -101,7 +101,7 @@ type HealthCheckFilterConfigFactory struct {
 
 func (f *HealthCheckFilterConfigFactory) CreateFilterChain(context context.Context, callbacks types.StreamFilterChainFactoryCallbacks) {
 	filter := NewHealthCheckFilter(context, f.FilterConfig)
-	callbacks.AddStreamReceiverFilter(filter, types.DownFilterAfterRoute)
+	callbacks.AddStreamReceiverFilter(filter, types.DownFilter)
 }
 
 // CreateHealthCheckFilterFactory

--- a/pkg/stream/sofarpc/connpool.go
+++ b/pkg/stream/sofarpc/connpool.go
@@ -291,7 +291,6 @@ func newActiveClient(ctx context.Context, subProtocol byte, pool *connPool) *act
 			keepAlive: NewSofaRPCKeepAlive(codecClient, subProtocol, time.Second, 6),
 		}
 		ac.client.AddConnectionEventListener(ac.keepAlive)
-		go ac.keepAlive.keepAlive.Start()
 	}
 
 	if err := ac.client.Connect(true); err != nil {

--- a/pkg/stream/sofarpc/keepalive_test.go
+++ b/pkg/stream/sofarpc/keepalive_test.go
@@ -81,7 +81,6 @@ func newTestCase(t *testing.T, srvTimeout, keepTimeout time.Duration, thres uint
 	}
 	// start a keep alive
 	keepAlive := NewSofaRPCKeepAlive(codec, sofarpc.PROTOCOL_CODE_V1, keepTimeout, thres)
-	go keepAlive.Start()
 	return &testCase{
 		KeepAlive: keepAlive.(*sofaRPCKeepAlive),
 		Server:    srv,

--- a/pkg/types/keepalive.go
+++ b/pkg/types/keepalive.go
@@ -20,7 +20,6 @@ package types
 import "time"
 
 type KeepAlive interface {
-	Start()
 	SendKeepAlive()
 	GetTimeout() time.Duration
 	HandleTimeout(id uint64)


### PR DESCRIPTION
1. keepalive不再开启goroutine，生成心跳包的时候同步生成
2. 心跳拦截改在路由之前