### PR TITLE
fix: resource default matcher headers relation misuse

### DIFF
--- a/pkg/filter/stream/commonrule/resource/defaultmatcher.go
+++ b/pkg/filter/stream/commonrule/resource/defaultmatcher.go
@@ -49,11 +49,11 @@ func (m *DefaultMatcher) Match(headers types.HeaderMap, resourceConfig *model.Re
 }
 
 func (*DefaultMatcher) matchHeaders(headers types.HeaderMap, resourceConfig *model.ResourceConfig) bool {
-	matched := resourceConfig.ParamsRelation != RelationOr
+	matched := resourceConfig.HeadersRelation != RelationOr
 	for _, comparison := range resourceConfig.Headers {
 		value, _ := headers.Get(comparison.Key)
 		flag := compare(comparison, value)
-		if resourceConfig.ParamsRelation != RelationOr {
+		if resourceConfig.HeadersRelation != RelationOr {
 			matched = matched && flag
 		} else {
 			matched = matched || flag

--- a/pkg/filter/stream/commonrule/resource/defaultmatcher_test.go
+++ b/pkg/filter/stream/commonrule/resource/defaultmatcher_test.go
@@ -267,3 +267,34 @@ func TestDefaultMatcher_Match13(t *testing.T) {
 		t.Errorf("false")
 	}
 }
+
+func TestDefaultMatcher_Match14(t *testing.T) {
+	matcher := &DefaultMatcher{}
+	resourceConfig := model.ResourceConfig{
+		Headers: []model.ComparisonCofig{
+			{
+				CompareType: CompareEquals,
+				Key:         protocol.MosnHeaderPathKey,
+				Value:       "/serverlist/xx.do",
+			},
+			{
+				CompareType: CompareEquals,
+				Key:         "x-application-header",
+				Value:       "app1",
+			},
+		},
+		HeadersRelation: RelationAnd,
+		Params:          params2,
+		ParamsRelation:  RelationOr,
+	}
+
+	headers := protocol.CommonHeader{
+		protocol.MosnHeaderPathKey:        "/serverlist/xx.do",
+		protocol.MosnHeaderQueryStringKey: "aa=va1&&bb=vb1",
+	}
+
+	res := matcher.Match(headers, &resourceConfig)
+	if res {
+		t.Errorf("false")
+	}
+}


### PR DESCRIPTION
### Issues associated with this PR

It's a simple fix about misuse of `HeadersRelation`/`ParamsRelation` in resource defaultmatcher.

### Solutions
use `HeadersRelation` as relation for `matchHeaders` instead of `ParamsRelation`.

### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
