### PR TITLE
Fix problem that on BiDirectionStreamConnection scene, no listenerTyp…

### DIFF
--- a/pkg/protocol/rpc/sofarpc/codec/boltv1.go
+++ b/pkg/protocol/rpc/sofarpc/codec/boltv1.go
@@ -410,6 +410,9 @@ func (sb *BoltV1SpanBuilder) BuildSpan(args ...interface{}) types.Span {
 
 	span.SetTag(trace.TRACE_ID, traceId)
 	lType := mosnctx.Get(ctx, types.ContextKeyListenerType)
+	if lType == nil {
+		return span
+	}
 
 	spanId := request.RequestHeader[models.RPC_ID_KEY]
 	if spanId == "" {


### PR DESCRIPTION
Fix problem that on BiDirectionStreamConnection scene, no listenerType context available while the upstream sends request. Just ignore the following tag data assemble cause we assume traceLog is not need for this scene.