### PR TITLE
fix startRWLoop panic.

### DIFF
--- a/pkg/network/connection.go
+++ b/pkg/network/connection.go
@@ -217,7 +217,8 @@ func (c *connection) startRWLoop(lctx context.Context) {
 		defer func() {
 			if p := recover(); p != nil {
 				log.DefaultLogger.Errorf("panic %v\n%s", p, string(debug.Stack()))
-				c.startReadLoop()
+
+				c.Close(types.NoFlush, types.LocalClose)
 			}
 		}()
 
@@ -229,7 +230,7 @@ func (c *connection) startRWLoop(lctx context.Context) {
 			if p := recover(); p != nil {
 				log.DefaultLogger.Errorf("panic %v\n%s", p, string(debug.Stack()))
 
-				c.startWriteLoop()
+				c.Close(types.NoFlush, types.LocalClose)
 			}
 		}()
 
@@ -637,6 +638,12 @@ func (c *connection) writeBufLen() (bufLen int) {
 }
 
 func (c *connection) Close(ccType types.ConnectionCloseType, eventType types.ConnectionEvent) error {
+	defer func() {
+		if p := recover(); p != nil {
+			log.DefaultLogger.Errorf("panic %v\n%s", p, string(debug.Stack()))
+		}
+	}()
+
 	if ccType == types.FlushWrite {
 		c.Write(buffer.NewIoBufferEOF())
 		return nil

--- a/pkg/proxy/downstream.go
+++ b/pkg/proxy/downstream.go
@@ -135,11 +135,11 @@ func newActiveStream(ctx context.Context, proxy *proxy, responseSender types.Str
 	stream.reuseBuffer = 1
 	stream.notify = make(chan struct{}, 1)
 
-	if responseSender != nil {
+	if responseSender == nil || reflect.ValueOf(responseSender).IsNil() {
+		stream.oneway = true
+	} else {
 		stream.responseSender = responseSender
 		stream.responseSender.GetStream().AddEventListener(stream)
-	} else {
-		stream.oneway = true
 	}
 
 	proxy.stats.DownstreamRequestTotal.Inc(1)

--- a/pkg/stream/sofarpc/stream.go
+++ b/pkg/stream/sofarpc/stream.go
@@ -276,11 +276,11 @@ func (conn *streamConnection) onNewStreamDetect(ctx context.Context, cmd sofarpc
 		log.Proxy.Infof(stream.ctx, "[stream] [sofarpc] new stream detect, requestId = %v", stream.id)
 	}
 
-	sender := stream
 	if cmd.CommandType() == sofarpc.REQUEST_ONEWAY {
-		sender = nil
+		stream.receiver = conn.serverStreamConnectionEventListener.NewStreamDetect(stream.ctx, nil, span)
+	} else {
+		stream.receiver = conn.serverStreamConnectionEventListener.NewStreamDetect(stream.ctx, stream, span)
 	}
-	stream.receiver = conn.serverStreamConnectionEventListener.NewStreamDetect(stream.ctx, sender, span)
 
 	return stream
 }


### PR DESCRIPTION
### Issues associated with this PR

Your PR should present related issues you want to solve.

### Sign the CLA
Make sure you have signed the [CLA](https://www.clahub.com/agreements/alipay/sofa-mosn)

### Solutions
当startReadLoop之后, recover里面重新调度startReadLoop, 如果再次panic, 将会不能捕捉. 将导致进程crash.



### UT result
Unit Test is needed if the code is changed, your unit test should cover boundary cases, corner cases, and some exceptional cases.
And you need to show the ut result.

### Benchmark
If your code involves the processing of every request, you should give the Benchmark Result

### Code Style
+ Make sure `Goimports` has run
+ Show `Golint` result
